### PR TITLE
Add stack limit inputs and capped stacking logic

### DIFF
--- a/truck_calculator/src/app/page.tsx
+++ b/truck_calculator/src/app/page.tsx
@@ -76,7 +76,7 @@ const MAX_GROSS_WEIGHT_KG = 24000;
 const MAX_PALLET_SIMULATION_QUANTITY = 300;
 const STACKED_EUP_THRESHOLD_FOR_AXLE_WARNING = 18;
 const STACKED_DIN_THRESHOLD_FOR_AXLE_WARNING = 16;
-const MAX_WEIGHT_PER_METER_KG = 1800;
+const MAX_WEIGHT_PER_METER_KG = 1700;
 
 
 // Core calculation logic (remains unchanged from your latest working version)
@@ -529,10 +529,10 @@ const calculateLoadingLogic = (
   const usedLengthPercentage = truckConfig.usableLength > 0 ? (usedLength / truckConfig.usableLength) * 100 : 0;
 
   const weightPerMeter = truckConfig.usableLength > 0 ? currentTotalWeight / (truckConfig.usableLength / 100) : 0;
-  if (weightPerMeter > MAX_WEIGHT_PER_METER_KG) {
+  if (weightPerMeter >= MAX_WEIGHT_PER_METER_KG) {
     tempWarnings.push(`ACHTUNG – mögliche Achslastüberschreitung: ${weightPerMeter.toFixed(1)} kg/m`);
   }
-  if (currentTotalWeight >= 11000 && usedLengthPercentage <= 40) {
+  if (currentTotalWeight >= 10500 && usedLengthPercentage <= 40) {
     tempWarnings.push('ACHTUNG – mehr als 11t auf weniger als 40% der Ladefläche');
   }
 

--- a/truck_calculator/src/app/page.tsx
+++ b/truck_calculator/src/app/page.tsx
@@ -677,13 +677,12 @@ export default function HomePage() {
     setTotalWeightKg(primaryResults.totalWeightKg);
     setActualEupLoadingPattern(primaryResults.eupLoadingPatternUsed);
     
-  }, [selectedTruck, eupQuantity, dinQuantity, isEUPStackable, isDINStackable, eupWeightPerPallet, dinWeightPerPallet, eupLoadingPattern]);
+  }, [selectedTruck, eupQuantity, dinQuantity, isEUPStackable, isDINStackable, eupWeightPerPallet, dinWeightPerPallet, eupLoadingPattern, eupStackLimit, dinStackLimit]);
 
   useEffect(() => {
-    // Pass current eupQuantity and dinQuantity to ensure the effect hook uses the latest state values
-    // for its initial calculation and for the remaining capacity checks.
-    calculateAndSetState('DIN_FIRST', eupQuantity, dinQuantity); 
-  }, [calculateAndSetState, eupQuantity, dinQuantity]); // Add eupQuantity and dinQuantity to dependency array
+    // Recalculate whenever quantities or stack limits change so the visualization stays in sync
+    calculateAndSetState('DIN_FIRST', eupQuantity, dinQuantity);
+  }, [calculateAndSetState, eupQuantity, dinQuantity, eupStackLimit, dinStackLimit]);
 
 
   const handleQuantityChange = (type, amount) => {

--- a/truck_calculator/src/app/page.tsx
+++ b/truck_calculator/src/app/page.tsx
@@ -76,7 +76,7 @@ const MAX_GROSS_WEIGHT_KG = 24000;
 const MAX_PALLET_SIMULATION_QUANTITY = 300;
 const STACKED_EUP_THRESHOLD_FOR_AXLE_WARNING = 18;
 const STACKED_DIN_THRESHOLD_FOR_AXLE_WARNING = 16;
-const MAX_WEIGHT_PER_METER_KG = 2500;
+const MAX_WEIGHT_PER_METER_KG = 1800;
 
 
 // Core calculation logic (remains unchanged from your latest working version)

--- a/truck_calculator/src/app/page.tsx
+++ b/truck_calculator/src/app/page.tsx
@@ -110,8 +110,16 @@ const calculateLoadingLogic = (
   const safeEupWeight = eupWeight > 0 ? eupWeight : 0;
   const safeDinWeight = dinWeight > 0 ? dinWeight : 0;
 
-  const allowedEupStack = currentIsEUPStackable ? (maxStackedEup ?? Infinity) : 0;
-  const allowedDinStack = currentIsDINStackable ? (maxStackedDin ?? Infinity) : 0;
+  const allowedEupStack = currentIsEUPStackable
+    ? (maxStackedEup && maxStackedEup > 0
+        ? Math.floor(maxStackedEup / 2)
+        : Infinity)
+    : 0;
+  const allowedDinStack = currentIsDINStackable
+    ? (maxStackedDin && maxStackedDin > 0
+        ? Math.floor(maxStackedDin / 2)
+        : Infinity)
+    : 0;
   let eupStacked = 0, dinStacked = 0;
 
   let unitsState = truckConfig.units.map(u => ({
@@ -895,7 +903,7 @@ export default function HomePage() {
                   value={dinStackLimit}
                   onChange={e=>setDinStackLimit(Math.max(0, parseInt(e.target.value,10)||0))}
                   className="mt-1 block w-full py-1 px-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-xs"
-                  placeholder="Max. Stapel"
+                  placeholder="Stapelbare Paletten (0 = alle)"
                 />
               )}
             </div>
@@ -925,7 +933,7 @@ export default function HomePage() {
                   value={eupStackLimit}
                   onChange={e=>setEupStackLimit(Math.max(0, parseInt(e.target.value,10)||0))}
                   className="mt-1 block w-full py-1 px-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-xs"
-                  placeholder="Max. Stapel"
+                  placeholder="Stapelbare Paletten (0 = alle)"
                 />
               )}
             </div>

--- a/truck_calculator/src/app/page.tsx
+++ b/truck_calculator/src/app/page.tsx
@@ -76,7 +76,7 @@ const MAX_GROSS_WEIGHT_KG = 24000;
 const MAX_PALLET_SIMULATION_QUANTITY = 300;
 const STACKED_EUP_THRESHOLD_FOR_AXLE_WARNING = 18;
 const STACKED_DIN_THRESHOLD_FOR_AXLE_WARNING = 16;
-const MAX_WEIGHT_PER_METER_KG = 1700;
+const MAX_WEIGHT_PER_METER_KG = 1800;
 
 
 // Core calculation logic (remains unchanged from your latest working version)
@@ -528,7 +528,7 @@ const calculateLoadingLogic = (
   const usedLength = truckConfig.maxWidth > 0 ? (finalTotalAreaBase / truckConfig.maxWidth) : 0;
   const usedLengthPercentage = truckConfig.usableLength > 0 ? (usedLength / truckConfig.usableLength) * 100 : 0;
 
-  const weightPerMeter = truckConfig.usableLength > 0 ? currentTotalWeight / (truckConfig.usableLength / 100) : 0;
+  const weightPerMeter = usedLength > 0 ? currentTotalWeight / (usedLength / 100) : 0;
   if (weightPerMeter >= MAX_WEIGHT_PER_METER_KG) {
     tempWarnings.push(`ACHTUNG – mögliche Achslastüberschreitung: ${weightPerMeter.toFixed(1)} kg/m`);
   }


### PR DESCRIPTION
## Summary
- allow specifying maximum number of stacked pallets
- show number inputs when stacking options are enabled
- support stack limits in loading calculations

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401f2b10648330b58df9be4a3c68bf