### PR TITLE
Fix rest filling calculations

### DIFF
--- a/truck_calculator/src/app/page.tsx
+++ b/truck_calculator/src/app/page.tsx
@@ -767,7 +767,7 @@ export default function HomePage() {
     const fillResults = calculateLoadingLogic(
       selectedTruck,
       MAX_PALLET_SIMULATION_QUANTITY, // Attempt to fill with EUPs
-      dinQuantity,                  // Keep current DINs
+      totalDinPalletsVisual,          // Use actually loaded DINs
       isEUPStackable,
       isDINStackable,
       eupWeightPerPallet, dinWeightPerPallet,
@@ -789,7 +789,7 @@ export default function HomePage() {
   };
 
   const handleFillRemainingWithDIN = () => {
-    const currentEupQty = eupQuantity;
+    const currentEupQty = totalEuroPalletsVisual;
     let bestSimResults = null;
 
     const currentTruckInfo = TRUCK_TYPES[selectedTruck];


### PR DESCRIPTION
## Summary
- use actually loaded pallets when filling remaining EUP or DIN pallets

## Testing
- `pnpm lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684161609a088330a5942af1bdfa6ebc