### PR TITLE
Stack and downgrade units for front zone

### DIFF
--- a/engine/src/sequence.ts
+++ b/engine/src/sequence.ts
@@ -1,11 +1,12 @@
 import { Bands, splitIntoBands } from './bands';
 import { PackOptions, PlanResult, FamilyBandConfig, TruckPreset, Item } from './types';
-import { formColumns, applyFrontZoneDowngrade } from './stacking';
+import { buildStackedBands, applyFrontZoneDowngrade, computeRowDepthByFamily } from './stacking';
 import { packBandSequence } from './packer';
 
-function getMaxHeightForFamily(famCfgs: FamilyBandConfig[], family: 'EUP' | 'DIN'): number {
-  const cfg = famCfgs.find((c) => c.family === family);
-  return cfg?.maxStackHeight ?? 2;
+function flattenColumnsToItems(columns: { units: Item[] }[]): Item[] {
+  const items: Item[] = [];
+  for (const c of columns) items.push(...c.units);
+  return items;
 }
 
 export function planWithFixedSequence(
@@ -17,24 +18,46 @@ export function planWithFixedSequence(
   // a) build bands (units)
   const unitBands: Bands = splitIntoBands(items, famCfgs);
 
-  // b) transform stacked units → columns
-  const eupMax = getMaxHeightForFamily(famCfgs, 'EUP');
-  const dinMax = getMaxHeightForFamily(famCfgs, 'DIN');
+  // b) transform stacked units → columns (+ leftover singles)
+  const stacked = buildStackedBands(unitBands, famCfgs);
 
-  const eupColumns = formColumns(unitBands.EUP_stacked, eupMax);
-  const dinColumns = formColumns(unitBands.DIN_stacked, dinMax);
+  // c) enforce front zone by downgrading overflow columns to singles
+  const rowDepthByFamily = computeRowDepthByFamily(preset, opts);
+  const downgrade = applyFrontZoneDowngrade(stacked, preset, opts, rowDepthByFamily);
 
-  // c) enforce stacked-only front zone via downgrade (overflow columns → singles)
-  const eupAfterZone: Item[] = applyFrontZoneDowngrade(eupColumns, opts.frontStagingDepth, preset);
-  const dinAfterZone: Item[] = applyFrontZoneDowngrade(dinColumns, opts.frontStagingDepth, preset);
+  // d) prepare final bands for packing
+  const EUP_stacked_items: Item[] = flattenColumnsToItems(downgrade.stacked.EUP_columns);
+  const DIN_stacked_items: Item[] = flattenColumnsToItems(downgrade.stacked.DIN_columns);
+
+  const EUP_unstacked: Item[] = [
+    ...unitBands.EUP_unstacked,
+    ...downgrade.stacked.EUP_singles, // leftover from forming columns
+    ...downgrade.downgraded.EUP, // overflow columns downgraded to singles
+  ];
+  const DIN_unstacked: Item[] = [
+    ...unitBands.DIN_unstacked,
+    ...downgrade.stacked.DIN_singles,
+    ...downgrade.downgraded.DIN,
+  ];
 
   const bandsForPacking: Bands = {
-    EUP_stacked: eupAfterZone,
-    DIN_stacked: dinAfterZone,
-    EUP_unstacked: unitBands.EUP_unstacked,
-    DIN_unstacked: unitBands.DIN_unstacked,
+    EUP_stacked: EUP_stacked_items,
+    DIN_stacked: DIN_stacked_items,
+    EUP_unstacked,
+    DIN_unstacked,
   };
 
-  // d) pack in fixed sequence (skip empty bands)
-  return packBandSequence(bandsForPacking, opts.fixedSequence, preset, opts);
+  // e) pack in fixed sequence (skip empty bands)
+  const packed = packBandSequence(bandsForPacking, opts.fixedSequence, preset, opts);
+
+  // f) append warnings
+  const notes = [
+    ...(packed.notes ?? []),
+    ...downgrade.warnings,
+  ];
+
+  return {
+    ...packed,
+    notes,
+  };
 }

--- a/engine/src/stacking.ts
+++ b/engine/src/stacking.ts
@@ -1,29 +1,139 @@
-import { Item, TruckPreset } from './types';
+import { Item, TruckPreset, PackOptions, FamilyBandConfig } from './types';
+import type { Bands } from './bands';
 
-export type Column = { items: Item[] };
+export interface Column {
+  units: Item[]; // length == stackHeight
+  height: number; // sum of unit heights
+  weight: number; // sum of unit weights
+  family: 'EUP' | 'DIN';
+}
 
-export function formColumns(items: Item[], maxStackHeight: number): Column[] {
-  if (maxStackHeight <= 1) return items.map((it) => ({ items: [it] }));
+function sumNumber(values: Array<number | undefined | null>): number {
+  let total = 0;
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) total += v;
+  }
+  return total;
+}
+
+function makeColumn(units: Item[]): Column {
+  const family = (units[0]?.family ?? 'EUP') as 'EUP' | 'DIN';
+  const height = sumNumber(units.map((u) => (u as any).heightMm));
+  const weight = sumNumber(units.map((u) => (u as any).weightKg));
+  return { units, height, weight, family };
+}
+
+export function formColumns(units: Item[], maxStackHeight: number): { columns: Column[]; singles: Item[] } {
+  if (maxStackHeight <= 1) {
+    return { columns: [], singles: [...units] };
+  }
+
   const columns: Column[] = [];
+  const singles: Item[] = [];
+
+  // Prefer full columns: greedily take groups of exactly maxStackHeight; leftover become singles
   let buffer: Item[] = [];
-  for (const it of items) {
-    buffer.push(it);
+  for (const unit of units) {
+    buffer.push(unit);
     if (buffer.length === maxStackHeight) {
-      columns.push({ items: buffer });
+      columns.push(makeColumn(buffer));
       buffer = [];
     }
   }
-  if (buffer.length > 0) columns.push({ items: buffer });
-  return columns;
+  if (buffer.length > 0) {
+    // Do not form a partial column; push leftover as singles
+    singles.push(...buffer);
+  }
+
+  return { columns, singles };
 }
 
-// Downgrade columns to singles if they cannot be placed within the front zone.
-// In this scaffold, we conservatively downgrade nothing based on capacity.
-// The packer is expected to place stacked items only in the front zone.
-export function applyFrontZoneDowngrade(columns: Column[], _frontStagingDepth: number, _preset: TruckPreset): Item[] {
-  // In a real implementation, calculate how many columns can fit within _frontStagingDepth
-  // and downgrade overflow columns to single items. For now, return items unchanged.
-  const items: Item[] = [];
-  for (const col of columns) items.push(...col.items);
-  return items;
+export interface StackedBands {
+  EUP_columns: Column[];
+  DIN_columns: Column[];
+  EUP_singles: Item[]; // leftover from stacked band
+  DIN_singles: Item[];
+}
+
+function getMaxStackHeightForFamily(famCfgs: FamilyBandConfig[], family: 'EUP' | 'DIN'): number {
+  const cfg = famCfgs.find((c) => c.family === family);
+  return cfg?.maxStackHeight ?? 2;
+}
+
+export function buildStackedBands(
+  bands: Bands,
+  famCfgs: FamilyBandConfig[]
+): StackedBands {
+  const eupMax = getMaxStackHeightForFamily(famCfgs, 'EUP');
+  const dinMax = getMaxStackHeightForFamily(famCfgs, 'DIN');
+
+  const { columns: EUP_columns, singles: EUP_singles } = formColumns(bands.EUP_stacked, eupMax);
+  const { columns: DIN_columns, singles: DIN_singles } = formColumns(bands.DIN_stacked, dinMax);
+
+  return { EUP_columns, DIN_columns, EUP_singles, DIN_singles };
+}
+
+export function computeRowDepthByFamily(_preset: TruckPreset, _opts: PackOptions): Record<'EUP' | 'DIN', number> {
+  // Example heuristic: both families use approximately 1200mm depth plus any needed clearances.
+  // Clearances can be parameterized later; keep simple for now.
+  const baseDepthMm = 1200;
+  const clearanceMm = 0;
+  return { EUP: baseDepthMm + clearanceMm, DIN: baseDepthMm + clearanceMm };
+}
+
+export function applyFrontZoneDowngrade(
+  stacked: StackedBands,
+  preset: TruckPreset,
+  opts: PackOptions,
+  rowDepthByFamily: Record<'EUP' | 'DIN', number>
+): {
+  stacked: StackedBands;
+  downgradedCount: number;
+  warnings: string[];
+  downgraded: { EUP: Item[]; DIN: Item[] };
+} {
+  const warnings: string[] = [];
+  let downgradedCount = 0;
+
+  function trimForFamily(columns: Column[], family: 'EUP' | 'DIN') {
+    const rowDepth = Math.max(1, Math.floor(rowDepthByFamily[family]));
+    const rowsFit = Math.max(0, Math.floor(opts.frontStagingDepth / rowDepth));
+
+    if (columns.length <= rowsFit) {
+      return { kept: columns, removed: [] as Column[], downgradedUnits: [] as Item[] };
+    }
+
+    const kept = columns.slice(0, rowsFit);
+    const removed = columns.slice(rowsFit);
+    const downgradedUnits = removed.flatMap((c) => c.units);
+    return { kept, removed, downgradedUnits };
+  }
+
+  const eupTrim = trimForFamily(stacked.EUP_columns, 'EUP');
+  if (eupTrim.removed.length > 0) {
+    const count = eupTrim.downgradedUnits.length;
+    downgradedCount += count;
+    warnings.push(`Stacked EUP: downgraded ${count} units; front zone capacity exceeded.`);
+  }
+
+  const dinTrim = trimForFamily(stacked.DIN_columns, 'DIN');
+  if (dinTrim.removed.length > 0) {
+    const count = dinTrim.downgradedUnits.length;
+    downgradedCount += count;
+    warnings.push(`Stacked DIN: downgraded ${count} units; front zone capacity exceeded.`);
+  }
+
+  const updated: StackedBands = {
+    EUP_columns: eupTrim.kept,
+    DIN_columns: dinTrim.kept,
+    EUP_singles: stacked.EUP_singles, // leftover from stacked band stays here; caller will append downgraded to unstacked bands
+    DIN_singles: stacked.DIN_singles,
+  };
+
+  return {
+    stacked: updated,
+    downgradedCount,
+    warnings,
+    downgraded: { EUP: eupTrim.downgradedUnits, DIN: dinTrim.downgradedUnits },
+  };
 }


### PR DESCRIPTION
Implement stacking transform and front-zone overflow downgrade to manage stacked units within the front staging area.

---
<a href="https://cursor.com/background-agent?bcId=bc-9acf2f65-984e-4ba2-90d8-c6ebe37f97c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9acf2f65-984e-4ba2-90d8-c6ebe37f97c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

