### PR TITLE
Pack bands with pair-consistent rows and heavy-forward bias

### DIFF
--- a/engine/dist/packer.js
+++ b/engine/dist/packer.js
@@ -1,22 +1,144 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.packBandSequence = packBandSequence;
-function packBandSequence(bands, sequence, _preset, _opts) {
-    const sequenceUsed = [];
-    const bandCounts = {
-        EUP_stacked: bands.EUP_stacked.length,
-        EUP_unstacked: bands.EUP_unstacked.length,
-        DIN_stacked: bands.DIN_stacked.length,
-        DIN_unstacked: bands.DIN_unstacked.length,
-    };
-    for (const bandName of sequence) {
-        const count = bandCounts[bandName] ?? 0;
-        if (count > 0)
-            sequenceUsed.push(bandName);
+function getFamilyWidthMm(f) {
+    return f === 'EUP' ? 800 : 1000;
+}
+function getFamilyDepthMm(f) {
+    return 1200;
+}
+function getUnitWeight(u) {
+    if (u.weight != null)
+        return u.weight; // Column has weight
+    const w = u.weightKg;
+    return typeof w === 'number' && Number.isFinite(w) ? w : 0;
+}
+function buildRowsForBand(kind, prepared) {
+    const family = kind.includes('EUP') ? 'EUP' : 'DIN';
+    const depth = getFamilyDepthMm(family);
+    let pool = [];
+    if (kind === 'EUP_stacked')
+        pool = [...prepared.EUP_columns];
+    if (kind === 'DIN_stacked')
+        pool = [...prepared.DIN_columns];
+    if (kind === 'EUP_unstacked')
+        pool = [...prepared.unstacked_EUP, ...prepared.EUP_singles];
+    if (kind === 'DIN_unstacked')
+        pool = [...prepared.unstacked_DIN, ...prepared.DIN_singles];
+    const rows = [];
+    // two-across, pair-consistent
+    for (let i = 0; i < pool.length; i += 2) {
+        const a = pool[i];
+        const b = pool[i + 1];
+        if (!b) {
+            // orphan; carry forward as potential remainder handled by caller
+            rows.push({ family, items: [a], weight: getUnitWeight(a), depthMm: depth });
+            break;
+        }
+        const rowItems = [a, b];
+        const weight = getUnitWeight(a) + getUnitWeight(b);
+        rows.push({ family, items: rowItems, weight, depthMm: depth });
     }
-    return {
+    return rows;
+}
+function packBandSequence(seq, prepared, preset, opts) {
+    const placements = [];
+    const rejected = [];
+    const notes = [];
+    let yCursor = 0; // front-to-back from bulkhead
+    const widthMm = preset.widthMm;
+    const lengthMm = preset.lengthMm;
+    const aisleReserve = Math.max(0, Math.floor(opts.aisleReserve ?? 0));
+    const usableLength = Math.max(0, lengthMm - aisleReserve);
+    const sequenceUsed = [];
+    const bandCounts = {};
+    for (const band of seq) {
+        // Build rows for this band
+        const rows = buildRowsForBand(band, prepared);
+        // Count items eligible in this band
+        const countInBand = rows.reduce((acc, r) => acc + (r.items.length >= 2 ? 2 : 1), 0);
+        bandCounts[band] = countInBand;
+        if (countInBand === 0)
+            continue;
+        // Sort heavy-forward within the band
+        const fullRows = rows.filter(r => r.items.length === 2);
+        const orphan = rows.find(r => r.items.length === 1);
+        fullRows.sort((a, b) => b.weight - a.weight);
+        const family = band.includes('EUP') ? 'EUP' : 'DIN';
+        const rowDepth = getFamilyDepthMm(family);
+        const rowWidth = getFamilyWidthMm(family) * 2; // two across
+        // Ensure fits width
+        if (rowWidth > widthMm) {
+            notes.push(`Row width ${rowWidth} exceeds truck width ${widthMm} for ${family}.`);
+            // reject all units in this band for width issue
+            for (const r of fullRows) {
+                for (const u of r.items)
+                    rejected.push({ item: u, reason: 'row-width' });
+            }
+            if (orphan)
+                rejected.push({ item: orphan.items[0], reason: 'row-width' });
+            continue;
+        }
+        // Place rows front-to-back within remaining length
+        let placedAny = false;
+        for (const row of fullRows) {
+            if (yCursor + rowDepth > usableLength) {
+                // cannot place more rows in this band; reject remaining in this band for length
+                for (const r of fullRows.slice(fullRows.indexOf(row))) {
+                    for (const u of r.items)
+                        rejected.push({ item: u, reason: opts.enforceRowPairConsistency ? 'pair-consistency' : 'length' });
+                }
+                if (orphan)
+                    rejected.push({ item: orphan.items[0], reason: opts.enforceRowPairConsistency ? 'pair-consistency' : 'length' });
+                break;
+            }
+            // x placement: two slots across width, same family per row
+            const slotW = getFamilyWidthMm(row.family);
+            const xLeft = Math.floor((widthMm - slotW * 2) / 2); // center the two-across
+            // left slot
+            placements.push({ x: xLeft, y: yCursor, w: slotW, h: rowDepth, rotated: false, idx: placements.length });
+            // right slot
+            placements.push({ x: xLeft + slotW, y: yCursor, w: slotW, h: rowDepth, rotated: false, idx: placements.length });
+            yCursor += rowDepth;
+            placedAny = true;
+        }
+        // If there is an orphan, enforce pair-consistency
+        if (orphan) {
+            if (yCursor + rowDepth <= usableLength) {
+                // Carry forward orphan to next band of same family if exists later in seq, else reject
+                const laterBandExists = seq.slice(seq.indexOf(band) + 1).some(b => b.includes(orphan.family));
+                if (!laterBandExists || !opts.enforceRowPairConsistency) {
+                    rejected.push({ item: orphan.items[0], reason: 'pair-consistency' });
+                }
+                else {
+                    notes.push(`Carried forward orphan ${orphan.family} unit for pairing in later band.`);
+                    // Put back into appropriate unstacked pool to pair later
+                    if (orphan.family === 'EUP')
+                        prepared.unstacked_EUP.unshift(orphan.items[0]);
+                    else
+                        prepared.unstacked_DIN.unshift(orphan.items[0]);
+                }
+            }
+            else {
+                rejected.push({ item: orphan.items[0], reason: 'pair-consistency' });
+            }
+        }
+        if (placedAny)
+            sequenceUsed.push(band);
+    }
+    const usedLengthMm = yCursor;
+    const result = {
         sequenceUsed,
         bandCounts,
-        notes: ['Packed using fixed sequence; empty bands skipped.'],
+        placements,
+        rejected,
+        notes: [
+            'Packed bands front-to-back with pair-consistent two-across rows and heavy-forward bias.',
+            `Aisle reserve ${aisleReserve}mm respected at rear.`,
+        ],
+        usedLengthMm,
+        usedWidthMm: widthMm,
+        usedHeightMm: preset.heightMm,
     };
+    return result;
 }

--- a/engine/dist/sequence.js
+++ b/engine/dist/sequence.js
@@ -4,27 +4,45 @@ exports.planWithFixedSequence = planWithFixedSequence;
 const bands_1 = require("./bands");
 const stacking_1 = require("./stacking");
 const packer_1 = require("./packer");
-function getMaxHeightForFamily(famCfgs, family) {
-    const cfg = famCfgs.find((c) => c.family === family);
-    return cfg?.maxStackHeight ?? 2;
+function flattenColumnsToItems(columns) {
+    const items = [];
+    for (const c of columns)
+        items.push(...c.units);
+    return items;
 }
 function planWithFixedSequence(items, famCfgs, preset, opts) {
     // a) build bands (units)
     const unitBands = (0, bands_1.splitIntoBands)(items, famCfgs);
-    // b) transform stacked units → columns
-    const eupMax = getMaxHeightForFamily(famCfgs, 'EUP');
-    const dinMax = getMaxHeightForFamily(famCfgs, 'DIN');
-    const eupColumns = (0, stacking_1.formColumns)(unitBands.EUP_stacked, eupMax);
-    const dinColumns = (0, stacking_1.formColumns)(unitBands.DIN_stacked, dinMax);
-    // c) enforce stacked-only front zone via downgrade (overflow columns → singles)
-    const eupAfterZone = (0, stacking_1.applyFrontZoneDowngrade)(eupColumns, opts.frontStagingDepth, preset);
-    const dinAfterZone = (0, stacking_1.applyFrontZoneDowngrade)(dinColumns, opts.frontStagingDepth, preset);
-    const bandsForPacking = {
-        EUP_stacked: eupAfterZone,
-        DIN_stacked: dinAfterZone,
-        EUP_unstacked: unitBands.EUP_unstacked,
-        DIN_unstacked: unitBands.DIN_unstacked,
+    // b) transform stacked units → columns (+ leftover singles)
+    const stacked = (0, stacking_1.buildStackedBands)(unitBands, famCfgs);
+    // c) enforce front zone by downgrading overflow columns to singles
+    const rowDepthByFamily = (0, stacking_1.computeRowDepthByFamily)(preset, opts);
+    const downgrade = (0, stacking_1.applyFrontZoneDowngrade)(stacked, preset, opts, rowDepthByFamily);
+    // d) prepare pools for packing
+    const prepared = {
+        EUP_columns: downgrade.stacked.EUP_columns,
+        DIN_columns: downgrade.stacked.DIN_columns,
+        EUP_singles: downgrade.stacked.EUP_singles,
+        DIN_singles: downgrade.stacked.DIN_singles,
+        // unstacked pools from original unstacked items plus downgraded overflow
+        unstacked_EUP: [
+            ...unitBands.EUP_unstacked,
+            ...downgrade.downgraded.EUP,
+        ],
+        unstacked_DIN: [
+            ...unitBands.DIN_unstacked,
+            ...downgrade.downgraded.DIN,
+        ],
     };
-    // d) pack in fixed sequence (skip empty bands)
-    return (0, packer_1.packBandSequence)(bandsForPacking, opts.fixedSequence, preset, opts);
+    // e) pack in fixed sequence (skip empty bands)
+    const packed = (0, packer_1.packBandSequence)(opts.fixedSequence, prepared, preset, opts);
+    // f) append warnings
+    const notes = [
+        ...(packed.notes ?? []),
+        ...downgrade.warnings,
+    ];
+    return {
+        ...packed,
+        notes,
+    };
 }

--- a/engine/dist/stacking.js
+++ b/engine/dist/stacking.js
@@ -1,31 +1,98 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.formColumns = formColumns;
+exports.buildStackedBands = buildStackedBands;
+exports.computeRowDepthByFamily = computeRowDepthByFamily;
 exports.applyFrontZoneDowngrade = applyFrontZoneDowngrade;
-function formColumns(items, maxStackHeight) {
-    if (maxStackHeight <= 1)
-        return items.map((it) => ({ items: [it] }));
+function sumNumber(values) {
+    let total = 0;
+    for (const v of values) {
+        if (typeof v === 'number' && Number.isFinite(v))
+            total += v;
+    }
+    return total;
+}
+function makeColumn(units) {
+    const family = (units[0]?.family ?? 'EUP');
+    const height = sumNumber(units.map((u) => u.heightMm));
+    const weight = sumNumber(units.map((u) => u.weightKg));
+    return { units, height, weight, family };
+}
+function formColumns(units, maxStackHeight) {
+    if (maxStackHeight <= 1) {
+        return { columns: [], singles: [...units] };
+    }
     const columns = [];
+    const singles = [];
+    // Prefer full columns: greedily take groups of exactly maxStackHeight; leftover become singles
     let buffer = [];
-    for (const it of items) {
-        buffer.push(it);
+    for (const unit of units) {
+        buffer.push(unit);
         if (buffer.length === maxStackHeight) {
-            columns.push({ items: buffer });
+            columns.push(makeColumn(buffer));
             buffer = [];
         }
     }
-    if (buffer.length > 0)
-        columns.push({ items: buffer });
-    return columns;
+    if (buffer.length > 0) {
+        // Do not form a partial column; push leftover as singles
+        singles.push(...buffer);
+    }
+    return { columns, singles };
 }
-// Downgrade columns to singles if they cannot be placed within the front zone.
-// In this scaffold, we conservatively downgrade nothing based on capacity.
-// The packer is expected to place stacked items only in the front zone.
-function applyFrontZoneDowngrade(columns, _frontStagingDepth, _preset) {
-    // In a real implementation, calculate how many columns can fit within _frontStagingDepth
-    // and downgrade overflow columns to single items. For now, return items unchanged.
-    const items = [];
-    for (const col of columns)
-        items.push(...col.items);
-    return items;
+function getMaxStackHeightForFamily(famCfgs, family) {
+    const cfg = famCfgs.find((c) => c.family === family);
+    return cfg?.maxStackHeight ?? 2;
+}
+function buildStackedBands(bands, famCfgs) {
+    const eupMax = getMaxStackHeightForFamily(famCfgs, 'EUP');
+    const dinMax = getMaxStackHeightForFamily(famCfgs, 'DIN');
+    const { columns: EUP_columns, singles: EUP_singles } = formColumns(bands.EUP_stacked, eupMax);
+    const { columns: DIN_columns, singles: DIN_singles } = formColumns(bands.DIN_stacked, dinMax);
+    return { EUP_columns, DIN_columns, EUP_singles, DIN_singles };
+}
+function computeRowDepthByFamily(_preset, _opts) {
+    // Example heuristic: both families use approximately 1200mm depth plus any needed clearances.
+    // Clearances can be parameterized later; keep simple for now.
+    const baseDepthMm = 1200;
+    const clearanceMm = 0;
+    return { EUP: baseDepthMm + clearanceMm, DIN: baseDepthMm + clearanceMm };
+}
+function applyFrontZoneDowngrade(stacked, preset, opts, rowDepthByFamily) {
+    const warnings = [];
+    let downgradedCount = 0;
+    function trimForFamily(columns, family) {
+        const rowDepth = Math.max(1, Math.floor(rowDepthByFamily[family]));
+        const rowsFit = Math.max(0, Math.floor(opts.frontStagingDepth / rowDepth));
+        if (columns.length <= rowsFit) {
+            return { kept: columns, removed: [], downgradedUnits: [] };
+        }
+        const kept = columns.slice(0, rowsFit);
+        const removed = columns.slice(rowsFit);
+        const downgradedUnits = removed.flatMap((c) => c.units);
+        return { kept, removed, downgradedUnits };
+    }
+    const eupTrim = trimForFamily(stacked.EUP_columns, 'EUP');
+    if (eupTrim.removed.length > 0) {
+        const count = eupTrim.downgradedUnits.length;
+        downgradedCount += count;
+        warnings.push(`Stacked EUP: downgraded ${count} units; front zone capacity exceeded.`);
+    }
+    const dinTrim = trimForFamily(stacked.DIN_columns, 'DIN');
+    if (dinTrim.removed.length > 0) {
+        const count = dinTrim.downgradedUnits.length;
+        downgradedCount += count;
+        warnings.push(`Stacked DIN: downgraded ${count} units; front zone capacity exceeded.`);
+    }
+    const updated = {
+        EUP_columns: eupTrim.kept,
+        DIN_columns: dinTrim.kept,
+        EUP_singles: stacked.EUP_singles, // leftover from stacked band stays here; caller will append downgraded to unstacked bands
+        DIN_singles: stacked.DIN_singles,
+    };
+    return {
+        stacked: updated,
+        downgradedCount,
+        warnings,
+        downgraded: { EUP: eupTrim.downgradedUnits, DIN: dinTrim.downgradedUnits },
+    };
 }

--- a/engine/src/packer.ts
+++ b/engine/src/packer.ts
@@ -1,28 +1,168 @@
-import { PackOptions, PlanResult, TruckPreset } from './types';
-import { Bands } from './bands';
+import { PackOptions, PlanResult, TruckPreset, Item, Placement } from './types';
+import { Column } from './stacking';
+
+// Row template: two-across for EUP (1200x800) and DIN (1200x1000).
+// Place columns (stacked) and singles (unstacked) as rows with two same-family slots per row.
+// If odd unit remains, carry to next row; if no depth left, reject with "pair-consistency".
+
+type SeqBand = 'DIN_stacked'|'EUP_stacked'|'DIN_unstacked'|'EUP_unstacked';
+
+interface Prepared {
+  EUP_columns: Column[]; DIN_columns: Column[];
+  EUP_singles: Item[];  DIN_singles: Item[];
+  unstacked_EUP: Item[]; // from bands
+  unstacked_DIN: Item[];
+}
+
+interface RowCandidate {
+  family: 'EUP'|'DIN';
+  items: (Item | Column)[]; // exactly 2 slots (same family)
+  weight: number; // sum weights
+  depthMm: number; // template depth by family
+}
+
+function getFamilyWidthMm(f: 'EUP'|'DIN'): number {
+  return f === 'EUP' ? 800 : 1000;
+}
+function getFamilyDepthMm(f: 'EUP'|'DIN'): number {
+  return 1200;
+}
+function getUnitWeight(u: Item | Column): number {
+  if ((u as any).weight != null) return (u as any).weight as number; // Column has weight
+  const w = (u as any).weightKg;
+  return typeof w === 'number' && Number.isFinite(w) ? w : 0;
+}
+
+function buildRowsForBand(kind: SeqBand, prepared: Prepared): RowCandidate[] {
+  const family: 'EUP'|'DIN' = kind.includes('EUP') ? 'EUP' : 'DIN';
+  const depth = getFamilyDepthMm(family);
+
+  let pool: Array<Item|Column> = [];
+  if (kind === 'EUP_stacked') pool = [...prepared.EUP_columns];
+  if (kind === 'DIN_stacked') pool = [...prepared.DIN_columns];
+  if (kind === 'EUP_unstacked') pool = [...prepared.unstacked_EUP, ...prepared.EUP_singles];
+  if (kind === 'DIN_unstacked') pool = [...prepared.unstacked_DIN, ...prepared.DIN_singles];
+
+  const rows: RowCandidate[] = [];
+  // two-across, pair-consistent
+  for (let i = 0; i < pool.length; i += 2) {
+    const a = pool[i];
+    const b = pool[i + 1];
+    if (!b) {
+      // orphan; carry forward as potential remainder handled by caller
+      rows.push({ family, items: [a], weight: getUnitWeight(a), depthMm: depth });
+      break;
+    }
+    const rowItems: (Item|Column)[] = [a, b];
+    const weight = getUnitWeight(a) + getUnitWeight(b);
+    rows.push({ family, items: rowItems, weight, depthMm: depth });
+  }
+  return rows;
+}
 
 export function packBandSequence(
-  bands: Bands,
-  sequence: PackOptions['fixedSequence'],
-  _preset: TruckPreset,
-  _opts: PackOptions
+  seq: SeqBand[],
+  prepared: Prepared,
+  preset: TruckPreset,
+  opts: PackOptions
 ): PlanResult {
-  const sequenceUsed: PlanResult['sequenceUsed'] = [];
-  const bandCounts: Record<string, number> = {
-    EUP_stacked: bands.EUP_stacked.length,
-    EUP_unstacked: bands.EUP_unstacked.length,
-    DIN_stacked: bands.DIN_stacked.length,
-    DIN_unstacked: bands.DIN_unstacked.length,
-  };
+  const placements: Placement[] = [];
+  const rejected: { item: Item; reason: string }[] = [];
+  const notes: string[] = [];
 
-  for (const bandName of sequence) {
-    const count = bandCounts[bandName] ?? 0;
-    if (count > 0) sequenceUsed.push(bandName as PlanResult['sequenceUsed'][number]);
+  let yCursor = 0; // front-to-back from bulkhead
+  const widthMm = preset.widthMm;
+  const lengthMm = preset.lengthMm;
+  const aisleReserve = Math.max(0, Math.floor(opts.aisleReserve ?? 0));
+  const usableLength = Math.max(0, lengthMm - aisleReserve);
+
+  const sequenceUsed: PlanResult['sequenceUsed'] = [];
+  const bandCounts: Record<string, number> = {};
+
+  for (const band of seq) {
+    // Build rows for this band
+    const rows = buildRowsForBand(band, prepared);
+    // Count items eligible in this band
+    const countInBand = rows.reduce((acc, r) => acc + (r.items.length >= 2 ? 2 : 1), 0);
+    bandCounts[band] = countInBand;
+    if (countInBand === 0) continue;
+
+    // Sort heavy-forward within the band
+    const fullRows = rows.filter(r => r.items.length === 2);
+    const orphan = rows.find(r => r.items.length === 1);
+    fullRows.sort((a, b) => b.weight - a.weight);
+
+    const family = band.includes('EUP') ? 'EUP' : 'DIN';
+    const rowDepth = getFamilyDepthMm(family);
+    const rowWidth = getFamilyWidthMm(family) * 2; // two across
+
+    // Ensure fits width
+    if (rowWidth > widthMm) {
+      notes.push(`Row width ${rowWidth} exceeds truck width ${widthMm} for ${family}.`);
+      // reject all units in this band for width issue
+      for (const r of fullRows) {
+        for (const u of r.items as Item[]) rejected.push({ item: u as Item, reason: 'row-width' });
+      }
+      if (orphan) rejected.push({ item: orphan.items[0] as Item, reason: 'row-width' });
+      continue;
+    }
+
+    // Place rows front-to-back within remaining length
+    let placedAny = false;
+    for (const row of fullRows) {
+      if (yCursor + rowDepth > usableLength) {
+        // cannot place more rows in this band; reject remaining in this band for length
+        for (const r of fullRows.slice(fullRows.indexOf(row))) {
+          for (const u of r.items as Item[]) rejected.push({ item: u as Item, reason: opts.enforceRowPairConsistency ? 'pair-consistency' : 'length' });
+        }
+        if (orphan) rejected.push({ item: orphan.items[0] as Item, reason: opts.enforceRowPairConsistency ? 'pair-consistency' : 'length' });
+        break;
+      }
+      // x placement: two slots across width, same family per row
+      const slotW = getFamilyWidthMm(row.family);
+      const xLeft = Math.floor((widthMm - slotW * 2) / 2); // center the two-across
+      // left slot
+      placements.push({ x: xLeft, y: yCursor, w: slotW, h: rowDepth, rotated: false, idx: placements.length });
+      // right slot
+      placements.push({ x: xLeft + slotW, y: yCursor, w: slotW, h: rowDepth, rotated: false, idx: placements.length });
+      yCursor += rowDepth;
+      placedAny = true;
+    }
+
+    // If there is an orphan, enforce pair-consistency
+    if (orphan) {
+      if (yCursor + rowDepth <= usableLength) {
+        // Carry forward orphan to next band of same family if exists later in seq, else reject
+        const laterBandExists = seq.slice(seq.indexOf(band) + 1).some(b => b.includes(orphan.family));
+        if (!laterBandExists || !opts.enforceRowPairConsistency) {
+          rejected.push({ item: orphan.items[0] as Item, reason: 'pair-consistency' });
+        } else {
+          notes.push(`Carried forward orphan ${orphan.family} unit for pairing in later band.`);
+          // Put back into appropriate unstacked pool to pair later
+          if (orphan.family === 'EUP') prepared.unstacked_EUP.unshift(orphan.items[0] as Item);
+          else prepared.unstacked_DIN.unshift(orphan.items[0] as Item);
+        }
+      } else {
+        rejected.push({ item: orphan.items[0] as Item, reason: 'pair-consistency' });
+      }
+    }
+
+    if (placedAny) sequenceUsed.push(band);
   }
 
-  return {
+  const usedLengthMm = yCursor;
+  const result: PlanResult = {
     sequenceUsed,
     bandCounts,
-    notes: ['Packed using fixed sequence; empty bands skipped.'],
+    placements,
+    rejected,
+    notes: [
+      'Packed bands front-to-back with pair-consistent two-across rows and heavy-forward bias.',
+      `Aisle reserve ${aisleReserve}mm respected at rear.`,
+    ],
+    usedLengthMm,
+    usedWidthMm: widthMm,
+    usedHeightMm: preset.heightMm,
   };
+  return result;
 }

--- a/engine/src/sequence.ts
+++ b/engine/src/sequence.ts
@@ -25,30 +25,25 @@ export function planWithFixedSequence(
   const rowDepthByFamily = computeRowDepthByFamily(preset, opts);
   const downgrade = applyFrontZoneDowngrade(stacked, preset, opts, rowDepthByFamily);
 
-  // d) prepare final bands for packing
-  const EUP_stacked_items: Item[] = flattenColumnsToItems(downgrade.stacked.EUP_columns);
-  const DIN_stacked_items: Item[] = flattenColumnsToItems(downgrade.stacked.DIN_columns);
-
-  const EUP_unstacked: Item[] = [
-    ...unitBands.EUP_unstacked,
-    ...downgrade.stacked.EUP_singles, // leftover from forming columns
-    ...downgrade.downgraded.EUP, // overflow columns downgraded to singles
-  ];
-  const DIN_unstacked: Item[] = [
-    ...unitBands.DIN_unstacked,
-    ...downgrade.stacked.DIN_singles,
-    ...downgrade.downgraded.DIN,
-  ];
-
-  const bandsForPacking: Bands = {
-    EUP_stacked: EUP_stacked_items,
-    DIN_stacked: DIN_stacked_items,
-    EUP_unstacked,
-    DIN_unstacked,
+  // d) prepare pools for packing
+  const prepared = {
+    EUP_columns: downgrade.stacked.EUP_columns,
+    DIN_columns: downgrade.stacked.DIN_columns,
+    EUP_singles: downgrade.stacked.EUP_singles,
+    DIN_singles: downgrade.stacked.DIN_singles,
+    // unstacked pools from original unstacked items plus downgraded overflow
+    unstacked_EUP: [
+      ...unitBands.EUP_unstacked,
+      ...downgrade.downgraded.EUP,
+    ],
+    unstacked_DIN: [
+      ...unitBands.DIN_unstacked,
+      ...downgrade.downgraded.DIN,
+    ],
   };
 
   // e) pack in fixed sequence (skip empty bands)
-  const packed = packBandSequence(bandsForPacking, opts.fixedSequence, preset, opts);
+  const packed = packBandSequence(opts.fixedSequence, prepared, preset, opts);
 
   // f) append warnings
   const notes = [

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -27,9 +27,28 @@ export interface TruckPreset {
   heightMm: number;
 }
 
+export interface Placement {
+  x: number;
+  y: number; // mm, front-to-back (0 at bulkhead)
+  w: number; // mm
+  h: number; // mm (row depth)
+  rotated: boolean;
+  idx: number; // running index for label
+}
+
 export interface PlanResult {
   sequenceUsed: Array<'DIN_stacked' | 'EUP_stacked' | 'DIN_unstacked' | 'EUP_unstacked'>;
   notes?: string[];
   // For simple validation/debugging
   bandCounts?: Record<string, number>;
+  // Floor plan placements
+  placements?: Placement[];
+  // Items that could not be placed and the reason
+  rejected?: { item: Item; reason: string }[];
+  // Optional warnings collected during planning
+  warnings?: string[];
+  // Utilization metrics
+  usedLengthMm?: number;
+  usedWidthMm?: number;
+  usedHeightMm?: number;
 }


### PR DESCRIPTION
Adds a new floor packer that arranges items into pair-consistent, heavy-forward rows within specified bands, optimizing truck loading by placing heavier rows first and handling orphan units.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c4696e3-cc26-4e6c-95ba-b4d79e6bafdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c4696e3-cc26-4e6c-95ba-b4d79e6bafdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

