### PR TITLE
Apply height checks and side-door warning

### DIFF
--- a/engine/dist/height.js
+++ b/engine/dist/height.js
@@ -1,0 +1,54 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.applyHeightChecks = applyHeightChecks;
+function getSideDoorHeight(preset) {
+    const v = preset?.sideDoorHeight;
+    const n = typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+    return n ?? 2650;
+}
+function getPlacementTop(placement) {
+    const z = typeof placement.z === 'number' ? placement.z : 0;
+    const height = typeof placement.stackHeightMm === 'number' ? placement.stackHeightMm : 0;
+    return z + height;
+}
+function applyHeightChecks(plan, preset) {
+    const sideDoorHeight = getSideDoorHeight(preset);
+    const innerHeight = preset.innerHeight ?? preset.heightMm ?? preset.height ?? 0;
+    const warnings = [...(plan.warnings ?? [])];
+    const notes = [...(plan.notes ?? [])];
+    const rejected = [...(plan.rejected ?? [])];
+    const placements = plan.placements ?? [];
+    const byXY = new Map();
+    for (const p of placements) {
+        const top = getPlacementTop(p);
+        const key = `${p.x},${p.y}`;
+        const prev = byXY.get(key);
+        if (!prev || top > prev.top) {
+            byXY.set(key, { top, x: p.x, y: p.y, idx: p.idx });
+        }
+        if (innerHeight && top > innerHeight) {
+            const units = Array.isArray(p.units) ? p.units : [];
+            if (units.length > 0) {
+                for (const u of units)
+                    rejected.push({ item: u, reason: 'overheight' });
+            }
+            else {
+                rejected.push({
+                    item: { family: 'EUP', qty: 1, id: `overheight@${p.x},${p.y}` },
+                    reason: 'overheight',
+                });
+            }
+        }
+    }
+    for (const entry of byXY.values()) {
+        if (entry.top > sideDoorHeight) {
+            warnings.push(`Side-door height risk at approx x=${entry.x}mm, y=${entry.y}mm: ${Math.round(entry.top)}mm exceeds ${sideDoorHeight}mm.`);
+        }
+    }
+    return {
+        ...plan,
+        warnings,
+        notes,
+        rejected,
+    };
+}

--- a/engine/dist/packer.js
+++ b/engine/dist/packer.js
@@ -41,6 +41,16 @@ function buildRowsForBand(kind, prepared) {
     }
     return rows;
 }
+function deriveUnitsAndHeight(u) {
+    if (u.units && u.height != null) {
+        const col = u;
+        return { units: [...col.units], heightMm: Math.max(0, Math.floor(col.height)) };
+    }
+    const item = u;
+    const h = item.heightMm;
+    const heightMm = typeof h === 'number' && Number.isFinite(h) ? Math.max(0, Math.floor(h)) : 0;
+    return { units: [item], heightMm };
+}
 function packBandSequence(seq, prepared, preset, opts) {
     const placements = [];
     const rejected = [];
@@ -95,10 +105,13 @@ function packBandSequence(seq, prepared, preset, opts) {
             // x placement: two slots across width, same family per row
             const slotW = getFamilyWidthMm(row.family);
             const xLeft = Math.floor((widthMm - slotW * 2) / 2); // center the two-across
+            // Left slot uses first item of the row, right slot uses second
+            const leftMeta = deriveUnitsAndHeight(row.items[0]);
+            const rightMeta = deriveUnitsAndHeight(row.items[1]);
             // left slot
-            placements.push({ x: xLeft, y: yCursor, w: slotW, h: rowDepth, rotated: false, idx: placements.length });
+            placements.push({ x: xLeft, y: yCursor, w: slotW, h: rowDepth, rotated: false, idx: placements.length, z: 0, stackHeightMm: leftMeta.heightMm, units: leftMeta.units });
             // right slot
-            placements.push({ x: xLeft + slotW, y: yCursor, w: slotW, h: rowDepth, rotated: false, idx: placements.length });
+            placements.push({ x: xLeft + slotW, y: yCursor, w: slotW, h: rowDepth, rotated: false, idx: placements.length, z: 0, stackHeightMm: rightMeta.heightMm, units: rightMeta.units });
             yCursor += rowDepth;
             placedAny = true;
         }

--- a/engine/dist/sequence.js
+++ b/engine/dist/sequence.js
@@ -4,6 +4,7 @@ exports.planWithFixedSequence = planWithFixedSequence;
 const bands_1 = require("./bands");
 const stacking_1 = require("./stacking");
 const packer_1 = require("./packer");
+const height_1 = require("./height");
 function flattenColumnsToItems(columns) {
     const items = [];
     for (const c of columns)
@@ -41,8 +42,9 @@ function planWithFixedSequence(items, famCfgs, preset, opts) {
         ...(packed.notes ?? []),
         ...downgrade.warnings,
     ];
+    // g) apply height checks and warnings
+    const withHeight = (0, height_1.applyHeightChecks)({ ...packed, notes }, preset);
     return {
-        ...packed,
-        notes,
+        ...withHeight,
     };
 }

--- a/engine/src/height.ts
+++ b/engine/src/height.ts
@@ -1,0 +1,64 @@
+import { PlanResult, TruckPreset } from './types';
+
+function getSideDoorHeight(preset: TruckPreset): number {
+  const v = (preset as any)?.sideDoorHeight;
+  const n = typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+  return n ?? 2650;
+}
+
+function getPlacementTop(placement: any): number {
+  const z = typeof placement.z === 'number' ? placement.z : 0;
+  const height = typeof placement.stackHeightMm === 'number' ? placement.stackHeightMm : 0;
+  return z + height;
+}
+
+export function applyHeightChecks(plan: PlanResult, preset: TruckPreset): PlanResult {
+  const sideDoorHeight = getSideDoorHeight(preset);
+  const innerHeight = (preset as any).innerHeight ?? (preset as any).heightMm ?? (preset as any).height ?? 0;
+
+  const warnings: string[] = [...(plan.warnings ?? [])];
+  const notes: string[] = [...(plan.notes ?? [])];
+  const rejected = [...(plan.rejected ?? [])];
+
+  const placements = plan.placements ?? [];
+
+  // Track max top per (x,y) anchor for warnings, while rejecting per offending placement
+  type MaxEntry = { top: number; x: number; y: number; idx?: number };
+  const byXY = new Map<string, MaxEntry>();
+
+  for (const p of placements as any[]) {
+    const top = getPlacementTop(p);
+    const key = `${p.x},${p.y}`;
+    const prev = byXY.get(key);
+    if (!prev || top > prev.top) {
+      byXY.set(key, { top, x: p.x, y: p.y, idx: p.idx });
+    }
+
+    if (innerHeight && top > innerHeight) {
+      const units = Array.isArray(p.units) ? p.units : [];
+      if (units.length > 0) {
+        for (const u of units) rejected.push({ item: u as any, reason: 'overheight' });
+      } else {
+        rejected.push({
+          item: { family: 'EUP', qty: 1, id: `overheight@${p.x},${p.y}` } as any,
+          reason: 'overheight',
+        });
+      }
+    }
+  }
+
+  for (const entry of byXY.values()) {
+    if (entry.top > sideDoorHeight) {
+      warnings.push(
+        `Side-door height risk at approx x=${entry.x}mm, y=${entry.y}mm: ${Math.round(entry.top)}mm exceeds ${sideDoorHeight}mm.`
+      );
+    }
+  }
+
+  return {
+    ...plan,
+    warnings,
+    notes,
+    rejected,
+  };
+}

--- a/engine/src/sequence.ts
+++ b/engine/src/sequence.ts
@@ -2,6 +2,7 @@ import { Bands, splitIntoBands } from './bands';
 import { PackOptions, PlanResult, FamilyBandConfig, TruckPreset, Item } from './types';
 import { buildStackedBands, applyFrontZoneDowngrade, computeRowDepthByFamily } from './stacking';
 import { packBandSequence } from './packer';
+import { applyHeightChecks } from './height';
 
 function flattenColumnsToItems(columns: { units: Item[] }[]): Item[] {
   const items: Item[] = [];
@@ -51,8 +52,10 @@ export function planWithFixedSequence(
     ...downgrade.warnings,
   ];
 
+  // g) apply height checks and warnings
+  const withHeight = applyHeightChecks({ ...packed, notes }, preset);
+
   return {
-    ...packed,
-    notes,
+    ...withHeight,
   };
 }

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -25,6 +25,9 @@ export interface TruckPreset {
   lengthMm: number;
   widthMm: number;
   heightMm: number;
+  // Optional more explicit fields for height logic
+  innerHeight?: number;       // if absent, fall back to heightMm
+  sideDoorHeight?: number;    // if absent, default 2650
 }
 
 export interface Placement {
@@ -34,6 +37,10 @@ export interface Placement {
   h: number; // mm (row depth)
   rotated: boolean;
   idx: number; // running index for label
+  // Vertical info for height checks (optional)
+  z?: number;                 // base elevation in mm (default 0)
+  stackHeightMm?: number;     // vertical height of the placed unit/column
+  units?: Item[];             // actual units represented by this placement slot
 }
 
 export interface PlanResult {


### PR DESCRIPTION
Add height validation to the packing plan, including warnings for side-door clearance and rejection for overheight units.

The new `applyHeightChecks` function calculates the top height for each placement. It issues a warning if any placement exceeds the `sideDoorHeight` (default 2650mm) and rejects units if they exceed the `innerHeight` of the truck. Placement data now includes `z`, `stackHeightMm`, and `units` to support these checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-832025ea-e44b-461f-9771-5d322113b453">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-832025ea-e44b-461f-9771-5d322113b453">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

