### PR TITLE
Sequence picker component for band reordering

### DIFF
--- a/truck_calculator/src/components/SequencePicker.tsx
+++ b/truck_calculator/src/components/SequencePicker.tsx
@@ -1,0 +1,32 @@
+'use client';
+import React from 'react';
+export type Band = 'DIN_stacked'|'EUP_stacked'|'DIN_unstacked'|'EUP_unstacked';
+
+export function SequencePicker({ seq, setSeq, visible }: {
+  seq: Band[]; setSeq:(b:Band[])=>void; visible: Set<Band>;
+}) {
+  const ALL: Band[] = ['DIN_stacked','EUP_stacked','DIN_unstacked','EUP_unstacked'];
+  const chips = ALL.filter(b => visible.has(b));
+  const move = (b:Band, dir:-1|1) => {
+    const i = seq.indexOf(b); if (i<0) return;
+    const j = Math.max(0, Math.min(seq.length-1, i+dir));
+    const copy = seq.slice(); [copy[i],copy[j]] = [copy[j],copy[i]]; setSeq(copy);
+  };
+  return (
+    <div className="space-y-2">
+      <div className="text-sm font-semibold">Sequence</div>
+      <div className="flex flex-wrap gap-2">
+        {chips.map(b=>(
+          <div key={b} className="flex items-center gap-1">
+            <span className="px-3 py-1 rounded-full border text-blue-600 border-blue-600">{b}</span>
+            <div className="flex flex-col gap-1">
+              <button type="button" className="px-2 border rounded" onClick={()=>move(b,-1)}>↑</button>
+              <button type="button" className="px-2 border rounded" onClick={()=>move(b, 1)}>↓</button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs opacity-70">Rule: stacked bands must stay in the front zone only.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a `SequencePicker` component to allow reordering of loading bands via interactive chips.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9e60783-15c7-4839-b5f6-200377e95902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9e60783-15c7-4839-b5f6-200377e95902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

