### PR TITLE
Configure pnpm workspace to two packages

### DIFF
--- a/truck_calculator/package.json
+++ b/truck_calculator/package.json
@@ -2,10 +2,6 @@
   "name": "truck_calculator",
   "version": "0.1.0",
   "private": true,
-  "workspaces": [
-    "engine",
-    "web"
-  ],
   "scripts": {
     "build": "pnpm -r run build",
     "test": "pnpm -r run test",


### PR DESCRIPTION
Remove 'workspaces' field from `truck_calculator/package.json` to lock the pnpm workspace to specified packages.

---
<a href="https://cursor.com/background-agent?bcId=bc-502ff164-4108-4ee3-ba5f-bf6e8dbb6387">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-502ff164-4108-4ee3-ba5f-bf6e8dbb6387">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

