### PR TITLE
Sort pallet queue for visual placement

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -165,6 +165,15 @@ const calculateLoadingLogic = (
     } else {
         palletQueue.push(...dinToStack, ...eupToStack, ...dinSingle, ...eupSingle);
     }
+    // Reorder palletQueue for correct visual placement: stacked EUPs, stacked DINs, standard DINs, standard EUPs
+    const getSortPriority = (pallet: { type: string; stacked: boolean }): number => {
+      if (pallet.type === 'euro' && pallet.stacked) return 1;
+      if (pallet.type === 'industrial' && pallet.stacked) return 2;
+      if (pallet.type === 'industrial' && !pallet.stacked) return 3;
+      if (pallet.type === 'euro' && !pallet.stacked) return 4;
+      return 5;
+    };
+    palletQueue.sort((a, b) => getSortPriority(a) - getSortPriority(b));
     
     let stopPlacement = false;
     for (const unit of unitsState) {


### PR DESCRIPTION
Sort `palletQueue` to prioritize stacked pallets at the front for accurate axle weight distribution visualization.

---
<a href="https://cursor.com/background-agent?bcId=bc-700c398c-7a30-4b34-8c8e-e3d255a4f10a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-700c398c-7a30-4b34-8c8e-e3d255a4f10a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

