### PR TITLE
Add glassmorphism styling overrides

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,3 +89,276 @@ body {
   }
 }
 
+/* Glassmorphism overrides */
+body {
+  min-height: 100vh;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(16, 185, 129, 0.15)),
+    linear-gradient(200deg, rgba(15, 118, 110, 0.2), rgba(37, 99, 235, 0.15));
+  background-attachment: fixed;
+  color: rgba(15, 23, 42, 0.95);
+}
+
+.glass-overlay {
+  position: relative;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 16px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
+}
+
+.glass-overlay:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.22);
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.header,
+.header.glass {
+  background: rgba(59, 130, 246, 0.8);
+  border-radius: 18px 18px 12px 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 18px 30px rgba(37, 99, 235, 0.25);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: rgba(241, 245, 249, 0.98);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.header .subtitle {
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.input-group label {
+  color: rgba(15, 23, 42, 0.85);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.input-group input,
+.input-group select,
+.input-group textarea,
+.input-group .input,
+.input-group .select,
+.input-group .number-input {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 12px;
+  padding: 0.65rem 0.85rem;
+  color: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.12);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.input-group input:focus,
+.input-group select:focus,
+.input-group textarea:focus,
+.input-group .input:focus,
+.input-group .select:focus,
+.input-group .number-input:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2), 0 16px 32px rgba(15, 23, 42, 0.18);
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.button-green,
+.button-green:hover,
+.button-green:focus,
+.button-green:active,
+.button-primary,
+button.button-green,
+button.button-primary,
+.button-green.secondary {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: rgba(34, 197, 94, 0.15);
+  color: rgba(6, 95, 70, 0.95);
+  box-shadow: 0 16px 28px rgba(16, 185, 129, 0.25);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: all 0.3s ease;
+}
+
+.button-green:hover,
+.button-primary:hover,
+button.button-green:hover,
+button.button-primary:hover {
+  background: rgba(34, 197, 94, 0.22);
+  box-shadow: 0 20px 38px rgba(16, 185, 129, 0.35);
+  transform: translateY(-2px);
+}
+
+.button-green:active,
+.button-primary:active,
+button.button-green:active,
+button.button-primary:active {
+  transform: translateY(1px);
+  box-shadow: 0 12px 22px rgba(16, 185, 129, 0.3);
+}
+
+.visualizer-panel,
+.visualizer-container,
+.visualizer {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 18px;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.visualizer-panel:hover,
+.visualizer-container:hover,
+.visualizer:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 32px 55px rgba(15, 23, 42, 0.22);
+}
+
+.checkbox-group,
+.radio-group,
+.option-glass,
+fieldset.glass,
+.input-group .toggle-group,
+.input-group .choice-group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 14px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 14px 22px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.checkbox-group:hover,
+.radio-group:hover,
+.option-glass:hover,
+fieldset.glass:hover,
+.input-group .toggle-group:hover,
+.input-group .choice-group:hover {
+  background: rgba(255, 255, 255, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 18px 28px rgba(15, 23, 42, 0.18);
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: rgba(34, 197, 94, 0.85);
+  width: 1.05rem;
+  height: 1.05rem;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
+  border-radius: 6px;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+input[type="checkbox"]:hover,
+input[type="radio"]:hover {
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.28);
+  transform: translateY(-1px);
+}
+
+.card,
+.panel,
+.section-glass {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.card:hover,
+.panel:hover,
+.section-glass:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 52px rgba(15, 23, 42, 0.2);
+}
+
+.table-glass,
+.table-glass thead,
+.table-glass tbody {
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.table-glass tr {
+  transition: background 0.25s ease;
+}
+
+.table-glass tr:hover {
+  background: rgba(59, 130, 246, 0.12);
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .glass-overlay,
+  .header,
+  .input-group input,
+  .input-group select,
+  .input-group textarea,
+  .button-green,
+  .button-primary,
+  .visualizer-panel,
+  .visualizer-container,
+  .visualizer,
+  .checkbox-group,
+  .radio-group,
+  .option-glass,
+  fieldset.glass,
+  .input-group .toggle-group,
+  .input-group .choice-group,
+  .card,
+  .panel,
+  .section-glass {
+    background: rgba(255, 255, 255, 0.9);
+  }
+}
+
+@media (max-width: 1024px) {
+  .header {
+    border-radius: 16px;
+  }
+
+  .visualizer-panel,
+  .visualizer-container,
+  .visualizer {
+    margin-top: 1.25rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .input-group {
+    gap: 0.55rem;
+  }
+
+  .button-green,
+  .button-primary,
+  button.button-green,
+  button.button-primary {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add glassmorphism-inspired overrides for the header, inputs, buttons, and visualizer panels
- introduce reusable glass overlay utility, responsive tweaks, and backdrops-filter fallbacks

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68d828f58b8c833081156e77f4059495