### PR TITLE
Apply ultra-glassmorphism styling to calculator UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -752,33 +752,50 @@ export default function HomePage() {
 
   const warningsWithoutInfo = warnings.filter(w => !w.toLowerCase().includes('platz') && !w.toLowerCase().includes('benötigt'));
   let meldungenStyle = {
-    bg: 'bg-gray-50', border: 'border-gray-200',
-    header: 'text-gray-800', list: 'text-gray-700'
+    bg: 'bg-gray-50',
+    border: 'border-gray-200/70',
+    header: 'text-slate-900',
+    list: 'text-slate-800/90'
   };
 
   if (warningsWithoutInfo.length === 0 && (totalDinPalletsVisual > 0 || totalEuroPalletsVisual > 0)) {
-    meldungenStyle = { bg: 'bg-green-50', border: 'border-green-200', header: 'text-green-800', list: 'text-green-700' };
+    meldungenStyle = {
+      bg: 'bg-green-50',
+      border: 'border-green-200/70',
+      header: 'text-emerald-900',
+      list: 'text-emerald-900/80'
+    };
   } else if (warningsWithoutInfo.some(w => w.toLowerCase().includes('konnte nicht'))) {
-    meldungenStyle = { bg: 'bg-red-50', border: 'border-red-200', header: 'text-red-800', list: 'text-red-700' };
+    meldungenStyle = {
+      bg: 'bg-red-50',
+      border: 'border-red-200/70',
+      header: 'text-rose-900',
+      list: 'text-rose-900/80'
+    };
   } else if (warningsWithoutInfo.length > 0) {
-    meldungenStyle = { bg: 'bg-yellow-50', border: 'border-yellow-200', header: 'text-yellow-800', list: 'text-yellow-700' };
+    meldungenStyle = {
+      bg: 'bg-yellow-50',
+      border: 'border-yellow-200/70',
+      header: 'text-amber-900',
+      list: 'text-amber-900/80'
+    };
   }
 
   return (
-    <div className="container mx-auto p-4 font-sans bg-gray-50">
-      <header className="relative bg-gradient-to-r from-blue-700 to-blue-900 text-white p-5 rounded-t-lg shadow-lg mb-6">
-        <div className="absolute top-2 right-4 text-right text-xs opacity-75">
+    <div className="container mx-auto p-6 font-sans text-slate-900">
+      <header className="relative bg-gradient-to-r from-blue-700 to-blue-900 text-slate-100 p-5 rounded-t-lg shadow-lg mb-6">
+        <div className="absolute top-2 right-4 text-right text-xs text-slate-100/80 drop-shadow-[0_1px_4px_rgba(15,23,42,0.65)]">
           <p>Laderaumrechner © {new Date().getFullYear()}</p>
           <p>by Andreas Steiner</p>
         </div>
-        <h1 className="text-3xl font-bold text-center tracking-tight">Laderaumrechner</h1>
-        <p className="text-center text-sm opacity-90">Visualisierung der Palettenplatzierung (Europäische Standards)</p>
+        <h1 className="text-3xl font-bold text-center tracking-tight drop-shadow-[0_8px_18px_rgba(15,23,42,0.45)]">Laderaumrechner</h1>
+        <p className="text-center text-sm text-slate-100/90 drop-shadow-[0_4px_12px_rgba(15,23,42,0.35)]">Visualisierung der Palettenplatzierung (Europäische Standards)</p>
       </header>
       <main className="p-6 bg-white shadow-lg rounded-b-lg">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
-          <div className="lg:col-span-1 space-y-6 bg-slate-50 p-5 rounded-lg border border-slate-200 shadow-sm">
+          <div className="lg:col-span-1 space-y-6 bg-slate-50 p-6 rounded-2xl border border-slate-200/70 shadow-xl">
             <div>
-              <label htmlFor="truckType" className="block text-sm font-medium text-gray-700 mb-1">LKW-Typ:</label>
+              <label htmlFor="truckType" className="block text-sm font-semibold text-slate-800 mb-1 tracking-wide">LKW-Typ:</label>
               <select 
                 id="truckType" 
                 value={selectedTruck} 
@@ -790,59 +807,94 @@ export default function HomePage() {
                     setIsDINStackable(false);
                   }
                 }} 
-                className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                className="mt-1 block w-full rounded-xl py-2.5 px-4 text-sm font-medium tracking-tight focus:outline-none"
+              >
                 {Object.keys(TRUCK_TYPES).map(key=><option key={key} value={key}>{TRUCK_TYPES[key as keyof typeof TRUCK_TYPES].name}</option>)}
               </select>
             </div>
             <div className="pt-4">
-              <button onClick={handleClearAllPallets} className="w-full py-2 px-4 bg-[#00906c] text-white font-semibold rounded-md shadow-sm hover:bg-[#007e5e] focus:outline-none focus:ring-2 focus:ring-[#00906c] focus:ring-opacity-50 transition duration-150 ease-in-out">Alles zurücksetzen</button>
+              <button
+                onClick={handleClearAllPallets}
+                className="w-full rounded-full py-3 text-base font-semibold uppercase tracking-[0.12em] drop-shadow-[0_18px_36px_rgba(16,185,129,0.45)]"
+              >
+                Alles zurücksetzen
+              </button>
             </div>
            
-            <div className="border-t pt-4">
-                <label className="block text-sm font-medium text-gray-700 mb-2">Industriepaletten (DIN)</label>
+            <div className="border-t border-white/30 pt-4">
+                <label className="block text-sm font-semibold text-slate-800 mb-2 tracking-wide">Industriepaletten (DIN)</label>
                 <WeightInputs entries={dinWeights} onChange={(entries)=>{ setLastEdited('din'); setDinWeights(entries); }} palletType="DIN" />
-                <button onClick={() => handleMaximizePallets('industrial')} className="mt-2 w-full py-1.5 px-3 bg-gradient-to-b from-[#00b382] to-[#00906c] text-white text-xs font-medium rounded-md shadow-sm hover:from-[#00906c] hover:to-[#007e5e] focus:outline-none focus:ring-2 focus:ring-[#00906c] focus:ring-opacity-50">Max. DIN</button>
-                <button onClick={() => handleFillRemaining('industrial')} className="mt-1 w-full py-1.5 px-3 bg-gradient-to-b from-[#008c6b] to-[#006951] text-white text-xs font-medium rounded-md shadow-sm hover:from-[#007e5e] hover:to-[#005f49] focus:outline-none focus:ring-2 focus:ring-[#008c6b] focus:ring-opacity-50">Rest mit max. DIN füllen</button>
-                <div className="flex items-center mt-2">
-                    <input type="checkbox" id="dinStackable" checked={isDINStackable} onChange={e=>setIsDINStackable(e.target.checked)} disabled={isWaggonSelected} className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"/>
-                    <label htmlFor="dinStackable" className={`ml-2 text-sm text-gray-900 ${isWaggonSelected && 'text-gray-400'}`}>Stapelbar (2-fach)</label>
+                <button
+                  onClick={() => handleMaximizePallets('industrial')}
+                  className="mt-3 w-full rounded-full py-2 text-xs font-semibold uppercase tracking-[0.16em] drop-shadow-[0_16px_32px_rgba(16,185,129,0.42)]"
+                >
+                  Max. DIN
+                </button>
+                <button
+                  onClick={() => handleFillRemaining('industrial')}
+                  className="mt-2 w-full rounded-full py-2 text-xs font-semibold uppercase tracking-[0.16em] drop-shadow-[0_16px_32px_rgba(16,185,129,0.38)]"
+                >
+                  Rest mit max. DIN füllen
+                </button>
+                <div className="flex items-center mt-3 rounded-xl">
+                    <input type="checkbox" id="dinStackable" checked={isDINStackable} onChange={e=>setIsDINStackable(e.target.checked)} disabled={isWaggonSelected} className="h-4 w-4 rounded-lg focus:ring-emerald-400 focus:ring-offset-0 disabled:cursor-not-allowed"/>
+                    <label htmlFor="dinStackable" className={`ml-3 text-sm font-medium text-slate-900 drop-shadow-[0_4px_12px_rgba(15,23,42,0.25)] ${isWaggonSelected && 'text-slate-500'}`}>Stapelbar (2-fach)</label>
                 </div>
                 {isDINStackable && !isWaggonSelected && (
-                    <input type="number" min="0" value={dinStackLimit} onChange={e=>setDinStackLimit(Math.max(0, parseInt(e.target.value,10)||0))} className="mt-1 block w-full py-1 px-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-xs" placeholder="Stapelbare Paletten (0 = alle)"/>
+                    <input type="number" min="0" value={dinStackLimit} onChange={e=>setDinStackLimit(Math.max(0, parseInt(e.target.value,10)||0))} className="mt-3 block w-full rounded-xl py-2 px-3 text-xs font-medium" placeholder="Stapelbare Paletten (0 = alle)"/>
                 )}
             </div>
 
-            <div className="border-t pt-4">
-                <label className="block text-sm font-medium text-gray-700 mb-2">Europaletten (EUP)</label>
+            <div className="border-t border-white/30 pt-4">
+                <label className="block text-sm font-semibold text-slate-800 mb-2 tracking-wide">Europaletten (EUP)</label>
                 <WeightInputs entries={eupWeights} onChange={(entries)=>{ setLastEdited('eup'); setEupWeights(entries); }} palletType="EUP" />
-                <button onClick={() => handleMaximizePallets('euro')} className="mt-2 w-full py-1.5 px-3 bg-gradient-to-b from-[#00b382] to-[#00906c] text-white text-xs font-medium rounded-md shadow-sm hover:from-[#00906c] hover:to-[#007e5e] focus:outline-none focus:ring-2 focus:ring-[#00906c] focus:ring-opacity-50">Max. EUP</button>
-                <button onClick={() => handleFillRemaining('euro')} className="mt-1 w-full py-1.5 px-3 bg-gradient-to-b from-[#008c6b] to-[#006951] text-white text-xs font-medium rounded-md shadow-sm hover:from-[#007e5e] hover:to-[#005f49] focus:outline-none focus:ring-2 focus:ring-[#008c6b] focus:ring-opacity-50">Rest mit max. EUP füllen</button>
-                <div className="flex items-center mt-2">
-                    <input type="checkbox" id="eupStackable" checked={isEUPStackable} onChange={e=>setIsEUPStackable(e.target.checked)} disabled={isWaggonSelected} className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"/>
-                    <label htmlFor="eupStackable" className={`ml-2 text-sm text-gray-900 ${isWaggonSelected && 'text-gray-400'}`}>Stapelbar (2-fach)</label>
+                <button
+                  onClick={() => handleMaximizePallets('euro')}
+                  className="mt-3 w-full rounded-full py-2 text-xs font-semibold uppercase tracking-[0.16em] drop-shadow-[0_16px_32px_rgba(16,185,129,0.42)]"
+                >
+                  Max. EUP
+                </button>
+                <button
+                  onClick={() => handleFillRemaining('euro')}
+                  className="mt-2 w-full rounded-full py-2 text-xs font-semibold uppercase tracking-[0.16em] drop-shadow-[0_16px_32px_rgba(16,185,129,0.38)]"
+                >
+                  Rest mit max. EUP füllen
+                </button>
+                <div className="flex items-center mt-3 rounded-xl">
+                    <input type="checkbox" id="eupStackable" checked={isEUPStackable} onChange={e=>setIsEUPStackable(e.target.checked)} disabled={isWaggonSelected} className="h-4 w-4 rounded-lg focus:ring-emerald-400 focus:ring-offset-0 disabled:cursor-not-allowed"/>
+                    <label htmlFor="eupStackable" className={`ml-3 text-sm font-medium text-slate-900 drop-shadow-[0_4px_12px_rgba(15,23,42,0.25)] ${isWaggonSelected && 'text-slate-500'}`}>Stapelbar (2-fach)</label>
                 </div>
                 {isEUPStackable && !isWaggonSelected && (
-                    <input type="number" min="0" value={eupStackLimit} onChange={e=>setEupStackLimit(Math.max(0, parseInt(e.target.value,10)||0))} className="mt-1 block w-full py-1 px-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-xs" placeholder="Stapelbare Paletten (0 = alle)"/>
+                    <input type="number" min="0" value={eupStackLimit} onChange={e=>setEupStackLimit(Math.max(0, parseInt(e.target.value,10)||0))} className="mt-3 block w-full rounded-xl py-2 px-3 text-xs font-medium" placeholder="Stapelbare Paletten (0 = alle)"/>
                 )}
             </div>
 
-            <div className="border-t pt-4">
-              <label className="block text-sm font-medium text-gray-700 mb-2">EUP Lade-Pattern:
-                <span className="text-xs text-gray-500"> (Gewählt: {actualEupLoadingPattern === 'none' ? 'Keines' : actualEupLoadingPattern})</span>
+            <div className="border-t border-white/30 pt-4">
+              <label className="block text-sm font-semibold text-slate-800 mb-2 tracking-wide">EUP Lade-Pattern:
+                <span className="text-xs text-slate-600/80"> (Gewählt: {actualEupLoadingPattern === 'none' ? 'Keines' : actualEupLoadingPattern})</span>
               </label>
               <div className="flex flex-col space-y-1">
-                <label className="flex items-center"><input type="radio" name="eupLoadingPattern" value="auto" checked={eupLoadingPattern==='auto'} onChange={e=>setEupLoadingPattern(e.target.value)} className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"/><span className="ml-2 text-sm text-gray-700">Auto-Optimieren</span></label>
-                <label className="flex items-center"><input type="radio" name="eupLoadingPattern" value="long" checked={eupLoadingPattern==='long'} onChange={e=>setEupLoadingPattern(e.target.value)} className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"/><span className="ml-2 text-sm text-gray-700">Längs (3 nebeneinander)</span></label>
-                <label className="flex items-center"><input type="radio" name="eupLoadingPattern" value="broad" checked={eupLoadingPattern==='broad'} onChange={e=>setEupLoadingPattern(e.target.value)} className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"/><span className="ml-2 text-sm text-gray-700">Quer (2 nebeneinander)</span></label>
+                <label className="flex items-center">
+                  <input type="radio" name="eupLoadingPattern" value="auto" checked={eupLoadingPattern==='auto'} onChange={e=>setEupLoadingPattern(e.target.value)} className="h-4 w-4 rounded-lg focus:ring-emerald-400"/>
+                  <span className="ml-3 text-sm font-medium text-slate-800/95">Auto-Optimieren</span>
+                </label>
+                <label className="flex items-center">
+                  <input type="radio" name="eupLoadingPattern" value="long" checked={eupLoadingPattern==='long'} onChange={e=>setEupLoadingPattern(e.target.value)} className="h-4 w-4 rounded-lg focus:ring-emerald-400"/>
+                  <span className="ml-3 text-sm font-medium text-slate-800/95">Längs (3 nebeneinander)</span>
+                </label>
+                <label className="flex items-center">
+                  <input type="radio" name="eupLoadingPattern" value="broad" checked={eupLoadingPattern==='broad'} onChange={e=>setEupLoadingPattern(e.target.value)} className="h-4 w-4 rounded-lg focus:ring-emerald-400"/>
+                  <span className="ml-3 text-sm font-medium text-slate-800/95">Quer (2 nebeneinander)</span>
+                </label>
               </div>
             </div>
           </div>
 
-          <div className="lg:col-span-2 bg-gray-100 p-6 rounded-lg border border-gray-200 shadow-sm flex flex-col items-center justify-center">
-            <p className="text-gray-700 text-lg mb-4 font-semibold">Ladefläche Visualisierung</p>
+          <div className="lg:col-span-2 bg-gray-100 p-6 rounded-2xl border border-gray-200/70 shadow-xl flex flex-col items-center justify-center">
+            <p className="mb-4 text-lg font-semibold tracking-wide drop-shadow-[0_12px_24px_rgba(15,23,42,0.4)]">Ladefläche Visualisierung</p>
             {palletArrangement.map((unit: any,index: number)=>(
               <div key={unit.unitId} className="mb-6 w-full flex flex-col items-center">
-                {TRUCK_TYPES[selectedTruck as keyof typeof TRUCK_TYPES].units.length>1&&<p className="text-sm text-gray-700 mb-2">Einheit {index+1} ({unit.unitLength/100}m x {unit.unitWidth/100}m)</p>}
+                {TRUCK_TYPES[selectedTruck as keyof typeof TRUCK_TYPES].units.length>1&&<p className="text-sm mb-2 text-slate-100/85 drop-shadow-[0_6px_14px_rgba(15,23,42,0.45)]">Einheit {index+1} ({unit.unitLength/100}m x {unit.unitWidth/100}m)</p>}
                 {index === 0 && (
                   <svg
                     aria-hidden
@@ -853,30 +905,32 @@ export default function HomePage() {
                     viewBox={`0 0 ${unit.unitWidth*truckVisualizationScale} 24`}
                   >
                     {/* Cab base */}
-                    <rect x="0" y="6" width={unit.unitWidth*truckVisualizationScale} height="16" rx="6" fill="#93c5fd" stroke="#60a5fa" />
+                    <rect x="0" y="6" width={unit.unitWidth*truckVisualizationScale} height="16" rx="6" fill="rgba(59, 130, 246, 0.4)" stroke="rgba(59, 130, 246, 0.65)" />
                     {/* Nose to indicate forward direction */}
-                    <path d={`M ${(unit.unitWidth*truckVisualizationScale)/2 - 12} 6 L ${(unit.unitWidth*truckVisualizationScale)/2} 0 L ${(unit.unitWidth*truckVisualizationScale)/2 + 12} 6 Z`} fill="#60a5fa" />
+                    <path d={`M ${(unit.unitWidth*truckVisualizationScale)/2 - 12} 6 L ${(unit.unitWidth*truckVisualizationScale)/2} 0 L ${(unit.unitWidth*truckVisualizationScale)/2 + 12} 6 Z`} fill="rgba(59, 130, 246, 0.5)" />
                     {/* Label */}
                     <text x={(unit.unitWidth*truckVisualizationScale)/2} y={20} textAnchor="middle" fontSize="10" fontWeight={700} fill="#1f2937">Front</text>
                   </svg>
                 )}
-                <div className="relative bg-gray-300 border-2 border-gray-500 overflow-hidden rounded-md shadow-inner" style={{width:`${unit.unitWidth*truckVisualizationScale}px`,height:`${unit.unitLength*truckVisualizationScale}px`}}>
+                <div
+                  className="relative overflow-hidden rounded-2xl border border-white/40 bg-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-2xl"
+                  style={{width:`${unit.unitWidth*truckVisualizationScale}px`,height:`${unit.unitLength*truckVisualizationScale}px`}}>
                   {unit.pallets.map((p: any)=>renderPallet(p,truckVisualizationScale))}
                 </div>
               </div>
             ))}
-             {palletArrangement.length === 0 && <p className="text-gray-500">Keine Paletten zum Anzeigen.</p>}
+             {palletArrangement.length === 0 && <p className="text-slate-100/80 drop-shadow-[0_6px_16px_rgba(15,23,42,0.45)]">Keine Paletten zum Anzeigen.</p>}
           </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          <div className="bg-blue-50 p-4 rounded-lg border border-blue-200 shadow-sm text-center">
-            <h3 className="font-semibold text-blue-800 mb-2">Geladene Paletten (Visuell)</h3>
-            <p>Industrie (DIN): <span className="font-bold text-lg">{totalDinPalletsVisual}</span></p>
-            <p>Euro (EUP): <span className="font-bold text-lg">{totalEuroPalletsVisual}</span></p>
-            <p className="text-xs mt-1">(Basis: {loadedIndustrialPalletsBase} DIN, {loadedEuroPalletsBase} EUP)</p>
+          <div className="bg-blue-50 p-5 rounded-2xl border border-blue-200/70 shadow-xl text-center">
+            <h3 className="mb-2 text-lg font-semibold tracking-wide text-slate-900 drop-shadow-[0_6px_14px_rgba(59,130,246,0.45)]">Geladene Paletten (Visuell)</h3>
+            <p className="text-sm text-slate-900/85">Industrie (DIN): <span className="font-bold text-xl text-slate-900/95">{totalDinPalletsVisual}</span></p>
+            <p className="text-sm text-slate-900/85">Euro (EUP): <span className="font-bold text-xl text-slate-900/95">{totalEuroPalletsVisual}</span></p>
+            <p className="mt-2 text-xs text-slate-900/70">(Basis: {loadedIndustrialPalletsBase} DIN, {loadedEuroPalletsBase} EUP)</p>
           </div>
-          <div className="bg-green-50 p-4 rounded-lg border border-green-200 shadow-sm text-center">
-            <h3 className="font-semibold text-green-800 mb-2">Verbleibende Kapazität</h3>
+          <div className="bg-green-50 p-5 rounded-2xl border border-green-200/70 shadow-xl text-center">
+            <h3 className="mb-2 text-lg font-semibold tracking-wide text-emerald-900 drop-shadow-[0_6px_14px_rgba(16,185,129,0.45)]">Verbleibende Kapazität</h3>
             {(() => {
               const firstType = lastEdited === 'din' ? 'DIN' : 'EUP';
               const secondType = lastEdited === 'din' ? 'EUP' : 'DIN';
@@ -884,29 +938,29 @@ export default function HomePage() {
               const secondValue = lastEdited === 'din' ? remainingCapacity.eup : remainingCapacity.din;
               return (
                 <>
-                  <p className="font-bold text-2xl text-green-700">Platz für:</p>
-                  <p className="font-bold text-2xl text-green-700">
+                  <p className="text-base font-semibold uppercase tracking-[0.2em] text-emerald-900/80">Platz für:</p>
+                  <p className="font-bold text-3xl text-emerald-950 drop-shadow-[0_8px_20px_rgba(16,185,129,0.35)]">
                     {firstValue} weitere {firstType} {firstValue === 1 ? 'Palette' : 'Paletten'}
                   </p>
-                  <p className="text-green-700">oder</p>
-                  <p className="font-bold text-xl text-green-700">
+                  <p className="text-sm uppercase tracking-[0.3em] text-emerald-800/80">oder</p>
+                  <p className="font-semibold text-2xl text-emerald-900/90">
                     {secondValue} weitere {secondType} {secondValue === 1 ? 'Palette' : 'Paletten'}
                   </p>
                 </>
               );
             })()}
           </div>
-          <div className="bg-yellow-50 p-4 rounded-lg border border-yellow-200 shadow-sm text-center">
-            <h3 className="font-semibold text-yellow-800 mb-2">Geschätztes Gewicht</h3>
-            <p className="font-bold text-2xl text-yellow-700">
+          <div className="bg-yellow-50 p-5 rounded-2xl border border-yellow-200/70 shadow-xl text-center">
+            <h3 className="mb-2 text-lg font-semibold tracking-wide text-amber-900 drop-shadow-[0_6px_14px_rgba(217,119,6,0.4)]">Geschätztes Gewicht</h3>
+            <p className="font-bold text-3xl text-amber-900/95 drop-shadow-[0_8px_20px_rgba(245,158,11,0.4)]">
               {KILOGRAM_FORMATTER.format(totalWeightKg)} kg
             </p>
-            <p className="text-xs mt-1">
+            <p className="mt-2 text-xs text-amber-900/80">
               (Max: {KILOGRAM_FORMATTER.format(maxGrossWeightKg)} kg)
             </p>
           </div>
-          <div className={`${meldungenStyle.bg} p-4 rounded-lg border ${meldungenStyle.border} shadow-sm`}>
-            <h3 className={`font-semibold mb-2 ${meldungenStyle.header}`}>Meldungen</h3>
+          <div className={`${meldungenStyle.bg} p-5 rounded-2xl border ${meldungenStyle.border} shadow-xl`}>
+            <h3 className={`mb-2 text-lg font-semibold tracking-wide drop-shadow-[0_6px_14px_rgba(15,23,42,0.35)] ${meldungenStyle.header}`}>Meldungen</h3>
             {warnings.length > 0 ? (
                 <ul className={`list-disc list-inside text-sm space-y-1 ${meldungenStyle.list}`}>
                 {warnings.map((w, i) => <li key={i}>{w}</li>)}
@@ -917,8 +971,8 @@ export default function HomePage() {
           </div>
         </div>
       </main>
-      <footer className="text-center py-4 mt-8 text-sm text-gray-500 border-t border-gray-200">
-        <p>Laderaumrechner © {new Date().getFullYear()} by Andreas Steiner</p>
+      <footer className="text-center py-4 mt-8 text-sm text-slate-100/80 border-t border-white/20 drop-shadow-[0_10px_24px_rgba(15,23,42,0.45)]">
+        <p className="tracking-wide">Laderaumrechner © {new Date().getFullYear()} by Andreas Steiner</p>
       </footer>
       <Toaster />
     </div>

--- a/src/components/WeightInputs.tsx
+++ b/src/components/WeightInputs.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 type WeightEntry = {
@@ -52,40 +51,38 @@ export function WeightInputs({ entries, onChange, palletType, preferredId, onSet
 
 
   return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <label className="w-20 text-center text-xs text-gray-600">Anzahl</label>
-        <label className="w-32 text-center text-xs text-gray-600">Gewicht/{palletType} (kg)</label>
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-slate-600/80">
+        <span className="w-20 text-center">Anzahl</span>
+        <span className="w-32 text-center">Gewicht/{palletType} (kg)</span>
       </div>
-      {entries.map((entry, index) => (
-        <div key={entry.id} className="flex items-center gap-2 mt-1">
-          <div className="flex items-center gap-1">
-            <Button
+      {entries.map((entry) => (
+        <div key={entry.id} className="flex items-center gap-3 mt-1 rounded-2xl rounded-md">
+          <div className="flex items-center gap-2 rounded-2xl rounded-md">
+            <button
               type="button"
-              variant="outline"
-              size="sm"
-              className="px-2"
+              aria-label="Menge verringern"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-lg font-semibold leading-none drop-shadow-[0_12px_24px_rgba(15,23,42,0.28)]"
               onClick={() => handleEntryChange(entry.id, 'quantity', String(Math.max(0, entry.quantity - 1)))}
             >
-              -
-            </Button>
+              −
+            </button>
             <Input
               type="number"
               min="0"
               value={entry.quantity}
               onChange={(e) => handleEntryChange(entry.id, 'quantity', e.target.value)}
               placeholder="Anzahl"
-              className="w-16 text-center"
+              className="w-20 text-center font-semibold tracking-wide"
             />
-            <Button
+            <button
               type="button"
-              variant="outline"
-              size="sm"
-              className="px-2"
+              aria-label="Menge erhöhen"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-lg font-semibold leading-none drop-shadow-[0_12px_24px_rgba(15,23,42,0.28)]"
               onClick={() => handleEntryChange(entry.id, 'quantity', String(entry.quantity + 1))}
             >
               +
-            </Button>
+            </button>
           </div>
           <Input
             type="number"
@@ -93,18 +90,27 @@ export function WeightInputs({ entries, onChange, palletType, preferredId, onSet
             value={entry.weight}
             onChange={(e) => handleEntryChange(entry.id, 'weight', e.target.value)}
             placeholder={`Gewicht/${palletType}`}
-            className="w-32 text-center"
+            className="w-32 text-center font-semibold tracking-wide"
           />
           {entries.length > 1 && (
-            <Button onClick={() => handleRemoveEntry(entry.id)} variant="destructive" size="sm">
-              -
-            </Button>
+            <button
+              type="button"
+              aria-label="Eintrag entfernen"
+              onClick={() => handleRemoveEntry(entry.id)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-lg font-semibold leading-none drop-shadow-[0_12px_24px_rgba(239,68,68,0.35)]"
+            >
+              ×
+            </button>
           )}
         </div>
       ))}
-      <Button onClick={handleAddEntry} className="mt-2" size="sm">
+      <button
+        type="button"
+        onClick={handleAddEntry}
+        className="mt-4 w-full rounded-full py-2 text-sm font-semibold uppercase tracking-[0.2em] drop-shadow-[0_16px_30px_rgba(59,130,246,0.35)]"
+      >
         Gewichtsgruppe hinzufügen
-      </Button>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refresh the landing header, panels, and metric cards to embrace the ultra-glass aesthetic with floating glass treatments and high-contrast typography
- update the cargo visualization container and cab SVG fills to maintain translucent depth within the new glassmorphism theme
- restyle the weight input controls and stack toggles with rounded glass buttons and consistent control chrome

## Testing
- `pnpm lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d97c0db60c8330b65ad60da74dc132