### PR TITLE
Implement axle-aware pallet stacking order

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -425,6 +425,11 @@ const calculateLoadingLogic = (
     // If we don't have enough singles, "unstack" pairs to create them
     while (workingSingles.length < REQUIRED_FRONT_SINGLES && workingPairGroups.length > 0) {
       const pairToUnstack = workingPairGroups.pop()!; // Take last pair
+      // Mark both pallets as NOT stacked and remove their stack group
+      for (const pallet of pairToUnstack) {
+        pallet.isStacked = false;
+        delete pallet.stackGroupId;
+      }
       // Add both pallets from the pair as singles
       workingSingles.push(...pairToUnstack);
       console.log(`  🔓 Unstacking pair to create singles (now have ${workingSingles.length} singles)`);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -434,6 +434,7 @@ const calculateLoadingLogic = (
     orderedType.push(...tailSingles);
 
     console.log(`  ✅ REORDERING: ${frontSingles.length} front singles, ${pairGroups.length} stacks (${pairGroups.length * 2} pallets), ${tailSingles.length} tail singles`);
+    console.log(`  Reordered sequence:`, orderedType.map((p, i) => `${i}:${p.isStacked ? 'S' : '-'}${p.stackGroupId || ''}`).join(' '));
 
     // Merge back, replacing only this type and keeping other types as-is
     const rebuilt: any[] = [];
@@ -444,6 +445,8 @@ const calculateLoadingLogic = (
     }
     return { manifest: rebuilt, applied: true };
   };
+
+  console.log('📋 BEFORE axle-aware:', finalPalletManifest.map((p, i) => `${i}:${p.type[0]}${p.isStacked ? 'S' : '-'}${p.stackGroupId || ''}`).join(' '));
 
   // Apply for DIN (industrial) → (26,42), base 26
   let tmp = reorderTypeAxleAware(finalPalletManifest, 'industrial', 26, 26, 42);
@@ -456,6 +459,8 @@ const calculateLoadingLogic = (
   finalPalletManifest = tmp.manifest;
   axleAwareApplied = axleAwareApplied || tmp.applied;
   if (tmp.applied) console.log('🎯 AXLE-AWARE APPLIED FOR EUP');
+
+  console.log('📋 AFTER axle-aware:', finalPalletManifest.map((p, i) => `${i}:${p.type[0]}${p.isStacked ? 'S' : '-'}${p.stackGroupId || ''}`).join(' '));
 
   // STAGE 2: PLACEMENT - Arrange the Manifest for Visualization
   const getPlacementPriority = (pallet: any) => {
@@ -568,10 +573,16 @@ const calculateLoadingLogic = (
         baseVisual.showAsFraction = true;
         const stackedLabelId = type === 'euro' ? (++eupLabelCounter) : (++dinLabelCounter);
         baseVisual.displayStackedLabelId = stackedLabelId;
+        if (type === 'industrial' && nextLabelId <= 30) {
+          console.log(`🏗️ Placing DIN stack at labels ${nextLabelId}/${stackedLabelId}, X=${currentX}, Y=${currentY}, queueIdx=${i}`);
+        }
         unit.palletsVisual.push(baseVisual);
         const topVisual = { ...baseVisual, isStackedTier: 'top', labelId: stackedLabelId, key: `${baseVisual.key}_stack` };
         unit.palletsVisual.push(topVisual);
       } else {
+        if (type === 'industrial' && nextLabelId <= 30) {
+          console.log(`🏗️ Placing DIN single at label ${nextLabelId}, X=${currentX}, Y=${currentY}, queueIdx=${i}`);
+        }
         unit.palletsVisual.push(baseVisual);
       }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -358,6 +358,81 @@ const calculateLoadingLogic = (
     warnings.push(`${truckConfig.name.trim()} maximale DIN-Kapazität ist ${maxDinBase}. Angeforderte Menge ${totalDinRequested}, es werden ${Math.min(maxDinBase, usedDinBasePositions)} platziert.`);
   }
 
+  // --- AXLE-AWARE REORDERING: start stacking at base position 9 when not fully double-stacked ---
+  // This reorders ONLY along the trailer length; it does not change counts, weights, or visuals.
+  // DIN: totals in (26, 42); base=26.  EUP: totals in (33, 50); base=33.
+  let axleAwareApplied = false;
+
+  const reorderTypeAxleAware = (
+    manifest: any[],
+    type: 'industrial' | 'euro',
+    baseCapacity: number,
+    lowerExclusive: number,
+    upperExclusive: number
+  ) => {
+    // Extract items of the type
+    const items = manifest.filter(p => p.type === type);
+    if (items.length === 0) return { manifest, applied: false };
+
+    // Group stacked pairs and collect singles
+    const pairBuckets = new Map<string, any[]>();
+    const singles: any[] = [];
+    for (const p of items) {
+      if (p.isStacked && p.stackGroupId) {
+        const k = String(p.stackGroupId);
+        if (!pairBuckets.has(k)) pairBuckets.set(k, []);
+        pairBuckets.get(k)!.push(p);
+      } else {
+        singles.push(p);
+      }
+    }
+    const pairGroups = Array.from(pairBuckets.values()).map(g =>
+      g.sort((a, b) => ((a.id ?? 0) - (b.id ?? 0)))
+    );
+
+    const totalLoaded = items.length;                          // base + tops
+    const stacksCount = pairGroups.length;                     // number of base positions taken by stacks
+    const basePositionsUsed = singles.length + stacksCount;    // base deck usage by this type
+
+    // Only apply when: stacks exist, base deck for this type is full, and we're in the mid-range window
+    const shouldApply =
+      stacksCount > 0 &&
+      basePositionsUsed === baseCapacity &&
+      totalLoaded > lowerExclusive &&
+      totalLoaded < upperExclusive;
+
+    if (!shouldApply) return { manifest, applied: false };
+
+    // Rule: positions 1..8 stay single; stacks begin at position 9; remainder singles follow.
+    const FRONT_SINGLES = 8;
+    const frontSingles = singles.slice(0, FRONT_SINGLES);
+    const tailSingles  = singles.slice(FRONT_SINGLES);
+
+    const orderedType: any[] = [];
+    orderedType.push(...frontSingles);
+    for (const grp of pairGroups) orderedType.push(...grp);
+    orderedType.push(...tailSingles);
+
+    // Merge back, replacing only this type and keeping other types as-is
+    const rebuilt: any[] = [];
+    let idx = 0;
+    for (const p of manifest) {
+      if (p.type === type) rebuilt.push(orderedType[idx++]);
+      else rebuilt.push(p);
+    }
+    return { manifest: rebuilt, applied: true };
+  };
+
+  // Apply for DIN (industrial) → (26,42), base 26
+  let tmp = reorderTypeAxleAware(finalPalletManifest, 'industrial', 26, 26, 42);
+  finalPalletManifest = tmp.manifest;
+  axleAwareApplied = axleAwareApplied || tmp.applied;
+
+  // Apply for EUP (euro) → (33,50), base 33
+  tmp = reorderTypeAxleAware(finalPalletManifest, 'euro', 33, 33, 50);
+  finalPalletManifest = tmp.manifest;
+  axleAwareApplied = axleAwareApplied || tmp.applied;
+
   // STAGE 2: PLACEMENT - Arrange the Manifest for Visualization
   const getPlacementPriority = (pallet: any) => {
     if (pallet.isStacked && pallet.type === 'industrial') return 1; // FIX: DIN stacked first
@@ -366,14 +441,16 @@ const calculateLoadingLogic = (
     if (!pallet.isStacked && pallet.type === 'euro') return 4;
     return 5;
   };
-  finalPalletManifest.sort((a, b) => {
-    const ap = getPlacementPriority(a);
-    const bp = getPlacementPriority(b);
-    if (ap !== bp) return ap - bp;
-    // Keep stack pairs together and stable order otherwise
-    if (a.stackGroupId && b.stackGroupId) return String(a.stackGroupId).localeCompare(String(b.stackGroupId));
-    return 0;
-  });
+  if (!axleAwareApplied) {
+    finalPalletManifest.sort((a, b) => {
+      const ap = getPlacementPriority(a);
+      const bp = getPlacementPriority(b);
+      if (ap !== bp) return ap - bp;
+      // Keep stack pairs together and stable order otherwise
+      if (a.stackGroupId && b.stackGroupId) return String(a.stackGroupId).localeCompare(String(b.stackGroupId));
+      return 0;
+    });
+  }
 
   // STAGE 2: PLACEMENT (This is the new, correct implementation)
   const unitsState = truckConfig.units.map((u: any) => ({ ...u, palletsVisual: [] as any[] }));


### PR DESCRIPTION
Implement axle-aware stacking order for road trucks to protect the front axle.

This change reorders pallets so that stacks begin at base position 9 for DIN (total > 26 and < 42) and EUP (total > 33 and < 50) pallets when the truck is not fully double-stacked. This prevents front axle overload in partially stacked scenarios, while fully double-stacked trucks retain the original stacking from position 1.

---
<a href="https://cursor.com/background-agent?bcId=bc-e300a2dd-3ebf-43d6-8c41-1d1c295d0fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e300a2dd-3ebf-43d6-8c41-1d1c295d0fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

