### PR TITLE
Implement axle-aware stacking reorder

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -408,10 +408,7 @@ const calculateLoadingLogic = (
     const frontSingles = singles.slice(0, FRONT_SINGLES);
     const tailSingles  = singles.slice(FRONT_SINGLES);
 
-    const orderedType: any[] = [];
-    orderedType.push(...frontSingles);
-    for (const grp of pairGroups) orderedType.push(...grp);
-    orderedType.push(...tailSingles);
+    const orderedType: any[] = [...frontSingles, ...pairGroups.flat(), ...tailSingles];
 
     // Merge back, replacing only this type and keeping other types as-is
     const rebuilt: any[] = [];


### PR DESCRIPTION
## Summary
- add axle-aware reordering logic that shifts stacked DIN/EUP pallets to start at base position 9 when double stacking is partial
- skip existing placement sort when axle-aware ordering applies to preserve calculated sequence

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c9ee371c83308129190bb3928bcd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds axle-aware manifest reordering that starts stacked DIN/EUP at base position 9 for partial double-stacking; skips placement sort when applied to preserve sequence.
> 
> - **Loading logic (`src/app/page.tsx`)**:
>   - **Axle-aware reorder**: Introduces `reorderTypeAxleAware` to reorder along trailer length without changing counts/weights.
>     - Applies when stacks exist, base deck for the type is full, and total loaded is within mid-range.
>     - Keeps first 8 singles, then stacked pairs, then remaining singles (stacks start at position 9).
>     - Applied separately for `industrial` (DIN: base 26, totals in (26, 42)) and `euro` (EUP: base 33, totals in (33, 50)).
>   - **Conditional placement sort**: Skips existing manifest sort if axle-aware ordering was applied; otherwise, refines sort to keep stack pairs together and stable by `id` within the same `stackGroupId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d056e134f6358b78050c59eefe96d7a2c9fa8c3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->