### PR TITLE
Add axis visualization and persistent info popup

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { Toaster } from '@/components/ui/toaster';
 import { WeightInputs } from '@/components/WeightInputs';
+import { StackingInfoDialog } from '@/components/StackingInfoDialog';
 
 // Define the type for a single weight entry
 type WeightEntry = {
@@ -1078,6 +1079,95 @@ export default function HomePage() {
                     WebkitBackdropFilter:'blur(26px)'
                   }}
                 >
+                  {/* Axis visualization */}
+                  <svg
+                    className="absolute inset-0 pointer-events-none"
+                    width={unit.unitWidth*truckVisualizationScale}
+                    height={unit.unitLength*truckVisualizationScale}
+                    style={{ zIndex: 1 }}
+                  >
+                    {/* Front axle (typically around 80-100cm from front) */}
+                    <line
+                      x1={0}
+                      y1={90*truckVisualizationScale}
+                      x2={unit.unitWidth*truckVisualizationScale}
+                      y2={90*truckVisualizationScale}
+                      stroke="rgba(239, 68, 68, 0.6)"
+                      strokeWidth={2}
+                      strokeDasharray="4,4"
+                    />
+                    <text
+                      x={unit.unitWidth*truckVisualizationScale - 2}
+                      y={90*truckVisualizationScale - 4}
+                      fontSize="9"
+                      fill="rgba(239, 68, 68, 0.85)"
+                      textAnchor="end"
+                      fontWeight={600}
+                    >
+                      Vorderachse
+                    </text>
+                    
+                    {/* Rear axle (typically around 120-150cm from rear) */}
+                    <line
+                      x1={0}
+                      y1={(unit.unitLength - 120)*truckVisualizationScale}
+                      x2={unit.unitWidth*truckVisualizationScale}
+                      y2={(unit.unitLength - 120)*truckVisualizationScale}
+                      stroke="rgba(239, 68, 68, 0.6)"
+                      strokeWidth={2}
+                      strokeDasharray="4,4"
+                    />
+                    <text
+                      x={unit.unitWidth*truckVisualizationScale - 2}
+                      y={(unit.unitLength - 120)*truckVisualizationScale - 4}
+                      fontSize="9"
+                      fill="rgba(239, 68, 68, 0.85)"
+                      textAnchor="end"
+                      fontWeight={600}
+                    >
+                      Hinterachse
+                    </text>
+                    
+                    {/* Stacking zone start marker for DIN (position 9 = 8 * 50cm = 400cm) */}
+                    <line
+                      x1={0}
+                      y1={400*truckVisualizationScale}
+                      x2={unit.unitWidth*truckVisualizationScale}
+                      y2={400*truckVisualizationScale}
+                      stroke="rgba(34, 197, 94, 0.5)"
+                      strokeWidth={1.5}
+                      strokeDasharray="2,2"
+                    />
+                    <text
+                      x={2}
+                      y={400*truckVisualizationScale - 4}
+                      fontSize="8"
+                      fill="rgba(34, 197, 94, 0.8)"
+                      fontWeight={500}
+                    >
+                      Stapeln DIN ab Pos. 9
+                    </text>
+                    
+                    {/* Stacking zone start marker for EUP (position 10 = 9 * 40cm = 360cm) */}
+                    <line
+                      x1={0}
+                      y1={360*truckVisualizationScale}
+                      x2={unit.unitWidth*truckVisualizationScale}
+                      y2={360*truckVisualizationScale}
+                      stroke="rgba(59, 130, 246, 0.5)"
+                      strokeWidth={1.5}
+                      strokeDasharray="2,2"
+                    />
+                    <text
+                      x={2}
+                      y={360*truckVisualizationScale + 12}
+                      fontSize="8"
+                      fill="rgba(59, 130, 246, 0.8)"
+                      fontWeight={500}
+                    >
+                      Stapeln EUP ab Pos. 10
+                    </text>
+                  </svg>
                   {unit.pallets.map((p: any)=>renderPallet(p,truckVisualizationScale))}
                 </div>
               </div>
@@ -1145,6 +1235,7 @@ export default function HomePage() {
       <footer className="text-center py-4 mt-8 text-sm text-slate-100/80 border-t border-gray-200">
         <p className="drop-shadow">Laderaumrechner © {new Date().getFullYear()} by Andreas Steiner</p>
       </footer>
+      <StackingInfoDialog />
       <Toaster />
     </div>
   );

--- a/src/components/StackingInfoDialog.tsx
+++ b/src/components/StackingInfoDialog.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+
+const STORAGE_KEY = 'stacking-info-dismissed';
+
+export function StackingInfoDialog() {
+  const [open, setOpen] = useState(false);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  useEffect(() => {
+    // Check if user has dismissed this dialog before
+    const dismissed = localStorage.getItem(STORAGE_KEY);
+    if (!dismissed) {
+      setOpen(true);
+    }
+  }, []);
+
+  const handleClose = () => {
+    if (dontShowAgain) {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    }
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Warum startet das Stapeln bei Position 9 (DIN) bzw. 10 (EUP)?</DialogTitle>
+          <DialogDescription className="pt-2 space-y-3">
+            <p className="text-sm text-slate-700">
+              Das Stapeln beginnt erst ab Position 9 bei DIN-Paletten bzw. ab Position 10 bei EUP-Paletten, 
+              um eine <strong>Achslastüberschreitung</strong> zu vermeiden.
+            </p>
+            <p className="text-sm text-slate-700">
+              Die vorderen Positionen (1-8 bei DIN, 1-9 bei EUP) bleiben zunächst frei, da hier die 
+              Gewichtsverteilung auf die Achsen besonders kritisch ist. Durch das Verschieben der 
+              schweren gestapelten Paletten in die mittleren und hinteren Bereiche des LKWs wird 
+              eine gleichmäßigere Lastverteilung erreicht.
+            </p>
+            <p className="text-sm text-slate-700">
+              Erst wenn der verfügbare Platz in der Stapelzone nicht ausreicht, wird die Ladung 
+              auf die gesamte Ladefläche erweitert. Dies gewährleistet sowohl eine optimale 
+              Raumnutzung als auch die Einhaltung der zulässigen Achslasten.
+            </p>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex-col sm:flex-row gap-2">
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="dont-show-again"
+              checked={dontShowAgain}
+              onCheckedChange={(checked) => setDontShowAgain(checked === true)}
+            />
+            <label
+              htmlFor="dont-show-again"
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+            >
+              Ich habe verstanden, nicht mehr anzeigen
+            </label>
+          </div>
+          <Button onClick={handleClose} className="w-full sm:w-auto">
+            Schließen
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Add an explanatory popup for stacking start positions and visualize truck axles to clarify weight distribution and prevent axis overloading.

---
<a href="https://cursor.com/background-agent?bcId=bc-945a92a5-57f2-4b81-a9d9-18ea4a13f72f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-945a92a5-57f2-4b81-a9d9-18ea4a13f72f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

