### PR TITLE
Fix remaining capacity calculation for mixed pallet loads

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -342,7 +342,7 @@ export const usePlannerStore = create<PlannerState>()(
         state.stackingStrategy,
       );
       const maxEup = eupCapacityResult.totalEuroPalletsVisual;
-      const remainingEup = Math.max(0, maxEup - eupQuantity);
+      const remainingEup = Math.max(0, maxEup - primaryResults.totalEuroPalletsVisual);
 
       const weightToFillDin = state.dinWeights.length > 0 ? state.dinWeights[state.dinWeights.length - 1].weight || '0' : '0';
       const dinCapacitySim = [{ id: -1, quantity: MAX_PALLET_SIMULATION_QUANTITY, weight: weightToFillDin, stackable: state.isDINStackable }];
@@ -359,7 +359,7 @@ export const usePlannerStore = create<PlannerState>()(
         state.stackingStrategy,
       );
       const maxDin = dinCapacityResult.totalDinPalletsVisual;
-      const remainingDin = Math.max(0, maxDin - dinQuantity);
+      const remainingDin = Math.max(0, maxDin - primaryResults.totalDinPalletsVisual);
 
       set(
         {


### PR DESCRIPTION
### Motivation
- Fix incorrect "Verbleibende Kapazität" where remaining space used raw input counts (`eupQuantity` / `dinQuantity`) and produced inconsistent DIN vs EUP values for mixed loads, since remaining capacity must reflect what the loading algorithm actually placed.

### Description
- Update `src/store.ts` to compute `remainingEup` and `remainingDin` by subtracting `primaryResults.totalEuroPalletsVisual` and `primaryResults.totalDinPalletsVisual` from the simulated family maxima (`eupCapacityResult.totalEuroPalletsVisual` / `dinCapacityResult.totalDinPalletsVisual`) so the UI badges report available slots based on the visualized load.

### Testing
- Ran unit tests with `pnpm vitest run` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da71f3b8c833082ba1cbea05adb98)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to UI-facing remaining-capacity calculations, using existing `calculateLoadingLogic` outputs; behavior only shifts for mixed loads where input quantities differed from placed pallets.
> 
> **Overview**
> Fixes remaining capacity (“Verbleibende Kapazität”) for mixed EUP/DIN loads by computing `remainingCapacity.eup`/`din` from the actually visualized placement (`primaryResults.totalEuroPalletsVisual` / `totalDinPalletsVisual`) instead of raw input quantities.
> 
> This makes the remaining-slot badges consistent with what the loading algorithm placed when mixed pallet types cause one type to be displaced/adjusted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3800b07b055030515ca38284d7987272b8c05c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->