### PR TITLE
Restore Waggon POE legacy pallet layout (38 EUP / 26 DIN)

### DIFF
--- a/src/lib/loading/logic.ts
+++ b/src/lib/loading/logic.ts
@@ -129,29 +129,23 @@ const calculateWaggonLayout = (
     const maxEup = Math.min(eupItems.length, 38);
     const laneStartY = 5;
 
+    const addEupLane = (count: number, palletWidth: number, palletHeight: number, xStep: number, yPos: number) => {
+      for (let i = 0; i < count && loadedEuro < maxEup; i++) {
+        const item = eupItems[loadedEuro];
+        mainUnit.pallets.push(createWaggonPallet(item, palletWidth, palletHeight, i * xStep, yPos));
+        loadedEuro++;
+        totalWeight += item.weight;
+      }
+    };
+
     // Lane 1: 11x EUP längs (80x120)
-    for (let i = 0; i < 11 && loadedEuro < maxEup; i++) {
-      const item = eupItems[loadedEuro];
-      mainUnit.pallets.push(createWaggonPallet(item, 80, 120, i * 120, laneStartY));
-      loadedEuro++;
-      totalWeight += item.weight;
-    }
+    addEupLane(11, 80, 120, 120, laneStartY);
 
     // Lane 2: 11x EUP längs (80x120)
-    for (let i = 0; i < 11 && loadedEuro < maxEup; i++) {
-      const item = eupItems[loadedEuro];
-      mainUnit.pallets.push(createWaggonPallet(item, 80, 120, i * 120, laneStartY + 80));
-      loadedEuro++;
-      totalWeight += item.weight;
-    }
+    addEupLane(11, 80, 120, 120, laneStartY + 80);
 
     // Lane 3: 16x EUP quer (120x80)
-    for (let i = 0; i < 16 && loadedEuro < maxEup; i++) {
-      const item = eupItems[loadedEuro];
-      mainUnit.pallets.push(createWaggonPallet(item, 120, 80, i * 80, laneStartY + 160));
-      loadedEuro++;
-      totalWeight += item.weight;
-    }
+    addEupLane(16, 120, 80, 80, laneStartY + 160);
 
     if (eupItems.length > loadedEuro) {
       warnings.push(`Platzmangel / Gewichtslimit: ${eupItems.length - loadedEuro} Paletten konnten nicht geladen werden.`);

--- a/src/lib/loading/logic.ts
+++ b/src/lib/loading/logic.ts
@@ -84,6 +84,121 @@ type PalletItem = {
   labelId: number;
 };
 
+const createVisualUnits = (truckConfig: (typeof TRUCK_TYPES)[keyof typeof TRUCK_TYPES]) =>
+  truckConfig.units.map(u => ({
+    unitId: u.id,
+    unitLength: u.length,
+    unitWidth: u.width,
+    pallets: [] as any[]
+  }));
+
+const createWaggonPallet = (
+  item: PalletItem,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+) => ({
+  key: item.id,
+  type: item.type,
+  width,
+  height,
+  x,
+  y,
+  labelId: item.labelId,
+  isStackedTier: 'base' as const,
+});
+
+const calculateWaggonLayout = (
+  truckConfig: (typeof TRUCK_TYPES)[keyof typeof TRUCK_TYPES],
+  eupItems: PalletItem[],
+  dinItems: PalletItem[],
+) => {
+  const visualUnits = createVisualUnits(truckConfig);
+  const mainUnit = visualUnits[0];
+  let loadedEuro = 0;
+  let loadedDin = 0;
+  let totalWeight = 0;
+  const warnings: string[] = [];
+
+  const onlyEup = eupItems.length > 0 && dinItems.length === 0;
+  const onlyDin = dinItems.length > 0 && eupItems.length === 0;
+
+  if (onlyEup) {
+    // Historic POE layout from previous versions: 38 EUP max.
+    const maxEup = Math.min(eupItems.length, 38);
+    const laneStartY = 5;
+
+    // Lane 1: 11x EUP längs (80x120)
+    for (let i = 0; i < 11 && loadedEuro < maxEup; i++) {
+      const item = eupItems[loadedEuro];
+      mainUnit.pallets.push(createWaggonPallet(item, 80, 120, i * 120, laneStartY));
+      loadedEuro++;
+      totalWeight += item.weight;
+    }
+
+    // Lane 2: 11x EUP längs (80x120)
+    for (let i = 0; i < 11 && loadedEuro < maxEup; i++) {
+      const item = eupItems[loadedEuro];
+      mainUnit.pallets.push(createWaggonPallet(item, 80, 120, i * 120, laneStartY + 80));
+      loadedEuro++;
+      totalWeight += item.weight;
+    }
+
+    // Lane 3: 16x EUP quer (120x80)
+    for (let i = 0; i < 16 && loadedEuro < maxEup; i++) {
+      const item = eupItems[loadedEuro];
+      mainUnit.pallets.push(createWaggonPallet(item, 120, 80, i * 80, laneStartY + 160));
+      loadedEuro++;
+      totalWeight += item.weight;
+    }
+
+    if (eupItems.length > loadedEuro) {
+      warnings.push(`Platzmangel / Gewichtslimit: ${eupItems.length - loadedEuro} Paletten konnten nicht geladen werden.`);
+    }
+  } else if (onlyDin) {
+    // Historic POE layout from previous versions: 26 DIN max.
+    const maxDin = Math.min(dinItems.length, 26);
+    const laneStartY = 25;
+
+    for (let i = 0; i < 13 && loadedDin < maxDin; i++) {
+      const left = dinItems[loadedDin];
+      mainUnit.pallets.push(createWaggonPallet(left, 120, 120, i * 120, laneStartY));
+      loadedDin++;
+      totalWeight += left.weight;
+
+      if (loadedDin < maxDin) {
+        const right = dinItems[loadedDin];
+        mainUnit.pallets.push(createWaggonPallet(right, 120, 120, i * 120, laneStartY + 120));
+        loadedDin++;
+        totalWeight += right.weight;
+      }
+    }
+
+    if (dinItems.length > loadedDin) {
+      warnings.push(`Platzmangel / Gewichtslimit: ${dinItems.length - loadedDin} Paletten konnten nicht geladen werden.`);
+    }
+  } else {
+    return null;
+  }
+
+  if (totalWeight > truckConfig.maxGrossWeightKg) {
+    warnings.push(`Gewicht überschritten: ${KILOGRAM_FORMATTER.format(totalWeight)} kg`);
+  }
+
+  return {
+    palletArrangement: visualUnits,
+    loadedIndustrialPalletsBase: loadedDin,
+    loadedEuroPalletsBase: loadedEuro,
+    totalDinPalletsVisual: loadedDin,
+    totalEuroPalletsVisual: loadedEuro,
+    utilizationPercentage: 0,
+    warnings: Array.from(new Set(warnings)),
+    totalWeightKg: totalWeight,
+    eupLoadingPatternUsed: onlyEup ? 'custom' : 'none',
+  };
+};
+
 function expandItems(
   weights: WeightEntry[],
   type: 'euro' | 'industrial',
@@ -137,6 +252,13 @@ export const calculateLoadingLogic = (
 
   const dinItems = dinItemsRaw.sort((a, b) => Number(a.stackable) - Number(b.stackable));
   const eupItems = eupItemsRaw.sort((a, b) => Number(a.stackable) - Number(b.stackable));
+
+  if (truckKey === 'waggon') {
+    const waggonLayout = calculateWaggonLayout(truckConfig, eupItems, dinItems);
+    if (waggonLayout) {
+      return waggonLayout;
+    }
+  }
 
   // 2. Phase A: Floor Loading
   


### PR DESCRIPTION
### Motivation
- The Waggon visualization and remaining-space logic regressed and must reflect the historical POE layout where a Waggon accepts up to 38 EUP in its legacy pattern but only 26 DIN in the matching DIN pattern.
- The UI and remaining-capacity calculations must match the old screenshots and produce consistent counts/warnings for single-family loads on the Waggon.

### Description
- Added a dedicated Waggon layout path implemented in `calculateWaggonLayout` and invoked early in `calculateLoadingLogic` for the `waggon` truck key so Waggon-only EUP or DIN loads use legacy geometry prior to the generic row algorithm.
- Implemented helpers `createVisualUnits` and `createWaggonPallet` to build the visual arrangement returned to the visualizer and to populate pallet properties (`labelId`, dimensions, x/y, stacked state).
- Restored historical capacities: EUP-only uses the 38-slot POE pattern (11 + 11 + 16) and DIN-only uses the 26-slot layout (13 × 2), and these counts are reflected in returned totals, weights and warnings.
- Mixed DIN+EUP loads still fall back to the existing generic placement and stacking algorithm so regular behavior is unchanged for mixed cases.

### Testing
- Built the app with `pnpm build` which completed successfully and produced the optimized build without type/lint failures.
- Launched the dev server and executed a Playwright-driven verification script that set Waggon + 38 EUP and Waggon + 26 DIN and captured screenshots; both scenarios rendered the expected legacy patterns (screenshots produced: `waggon-eup-38.png`, `waggon-din-26.png`).
- No automated unit test suite was modified; verification was performed via the build and visual browser automation and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698db6718a5c83308b95e4b41658a56d)